### PR TITLE
Add Person schema markup to homepage

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -5,3 +5,29 @@
 <meta name="google-site-verification" content="Zds1YXaC6gE0uMFQVGFXVjXkXYc3OpEZzuSJE_oBQ-k" />
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2418700819447994"
      crossorigin="anonymous"></script>
+
+{% if page.url == "/" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Kiran Shahi",
+  "url": "https://kirans.me",
+  "jobTitle": "AI Researcher & Software Engineer",
+  "alumniOf": {
+    "@type": "CollegeOrUniversity",
+    "name": "Brunel University London"
+  },
+  "sameAs": [
+    "https://dev.to/kiranshahi",
+    "https://scholar.google.com/citations?user=UY8GlccAAAAJ&hl=en",
+    "https://orcid.org/0000-0003-3739-5985",
+    "https://stackoverflow.com/users/5740382/kiran-shahi",
+    "https://www.linkedin.com/in/kiranshahi/",
+    "https://about.me/kiranshahi",
+    "https://www.kaggle.com/kiranshahi",
+    "https://github.com/kiranshahi"
+  ]
+}
+</script>
+{% endif %}


### PR DESCRIPTION
## Summary
- add Person JSON-LD schema to home page head

## Testing
- `bundle exec jekyll build` *(fails: bundler could not find jekyll)*
- `bundle install` *(fails: 403 Forbidden when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b5b5e074832787fa26840816ec9b