### PR TITLE
Add research and contact pages

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -1,0 +1,13 @@
+---
+title: "Contact"
+layout: single
+permalink: /contact/
+---
+
+I'm always happy to connect with fellow developers, researchers, and collaborators.
+
+- Email: [kiran.shahi.c3@gmail.com](mailto:kiran.shahi.c3@gmail.com)
+- LinkedIn: [linkedin.com/in/kiranshahi](https://www.linkedin.com/in/kiranshahi/)
+- GitHub: [github.com/kiranshahi](https://github.com/kiranshahi)
+
+Feel free to reach out with questions, ideas, or just to say hello.

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,0 +1,11 @@
+---
+title: "Research"
+layout: single
+permalink: /research/
+---
+
+My research focuses on applying deep learning and computer vision to solve real-world problems.
+
+I am particularly interested in neural networks for image understanding, automation, and intelligent systems.
+
+This page highlights ongoing projects, publications, and ideas I'm experimenting with.


### PR DESCRIPTION
## Summary
- add Research page outlining current interests and projects
- add Contact page with email and social links

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a1b90078888327b1b9d1359997859f