### PR TITLE
Add Google Scholar and ORCID links to footer

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,9 +72,16 @@ footer:
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
       url: "https://github.com/kiranshahi"
-    - label: "Linkedin"
+    - label: "LinkedIn"
       icon: "fab fa-linkedin"
       url: "https://www.linkedin.com/in/kiranshahi/"
+    - label: "Google Scholar"
+      icon: "ai ai-google-scholar"
+      url: "https://scholar.google.com/citations?user=UY8GlccAAAAJ&hl=en"
+    - label: "ORCID"
+      icon: "ai ai-orcid"
+      url: "https://orcid.org/0000-0003-3739-5985"
+    # add any other external profiles here
 
 defaults:
   # _posts


### PR DESCRIPTION
## Summary
- extend footer links with Google Scholar and ORCID profiles

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a1b9a3a34083279b8b7c0b719a1354