### PR TITLE
feat: add connect section to homepage

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -14,5 +14,16 @@ layout: default
 
   {% include featured-research.html %}
 
+  <section class="lets-connect text-center">
+    <h2>Let's Connect</h2>
+    <p>Interested in collaborating or have a question? I'd love to hear from you.</p>
+    <div class="connect__actions">
+      <a class="btn btn--primary" href="mailto:kiran.shahi.c3@gmail.com">Email</a>
+      <a class="btn btn--primary" href="https://www.linkedin.com/in/kiranshahi/" target="_blank" rel="noopener">LinkedIn</a>
+      <a class="btn btn--primary" href="https://github.com/kiranshahi" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p><a href="#site-footer">More contact options</a></p>
+  </section>
+
   {{ content }}
 </div>


### PR DESCRIPTION
## Summary
- add "Let's Connect" section under research cards on home layout
- include email, LinkedIn, GitHub buttons with optional footer link

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bd68b53c83278b40a341a7de87be