### PR TITLE
Add social media meta tags for homepage

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -8,6 +8,13 @@
 <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
 
 {% if page.url == "/" %}
+<meta property="og:title" content="{{ site.title }}">
+<meta property="og:description" content="{{ site.description | strip_newlines }}">
+<meta property="og:image" content="{{ '/assets/images/kiran-shahi.JPG' | relative_url }}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{ site.title }}">
+<meta name="twitter:description" content="{{ site.description | strip_newlines }}">
+<meta name="twitter:image" content="{{ '/assets/images/kiran-shahi.JPG' | relative_url }}">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter card metadata for the homepage
- ensure meta tags only render on the index page

## Testing
- `npm install open-graph-scraper` *(fails: 403 Forbidden)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1be729ad08327bf12f9c0766209b3