### PR TITLE
Add revealable email on contact page

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -6,8 +6,22 @@ permalink: /contact/
 
 I'm always happy to connect with fellow developers, researchers, and collaborators.
 
-- Email: [kiran.shahi.c3@gmail.com](mailto:kiran.shahi.c3@gmail.com)
+- Email: <span id="email-placeholder">****</span>  
+  <button id="reveal-email">Show Email</button>
 - LinkedIn: [linkedin.com/in/kiranshahi](https://www.linkedin.com/in/kiranshahi/)
 - GitHub: [github.com/kiranshahi](https://github.com/kiranshahi)
 
 Feel free to reach out with questions, ideas, or just to say hello.
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const btn = document.getElementById('reveal-email');
+  const span = document.getElementById('email-placeholder');
+  if (btn && span) {
+    btn.addEventListener('click', function() {
+      span.textContent = 'kiran.shahi.c3[at]gmail.com';
+      btn.remove();
+    });
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- hide contact email behind a reveal button to deter bots
- add inline script to display email and remove button when clicked

## Testing
- `bundle install` *(fails: 403 "Forbidden" fetching gems)*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c1ea2d908327af7612603c8f9326