### PR TITLE
Add icons and flex styling for home connect buttons

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -20,9 +20,9 @@ layout: default
     <h2>Let's Connect</h2>
     <p>Interested in collaborating or have a question? I'd love to hear from you.</p>
     <div class="connect__actions">
-      <a class="btn btn--primary" href="mailto:kiran.shahi.c3@gmail.com">Email</a>
-      <a class="btn btn--primary" href="https://www.linkedin.com/in/kiranshahi/" target="_blank" rel="noopener">LinkedIn</a>
-      <a class="btn btn--primary" href="https://github.com/kiranshahi" target="_blank" rel="noopener">GitHub</a>
+      <a class="btn btn--primary" href="mailto:kiran.shahi.c3@gmail.com"><i class="fas fa-envelope" aria-hidden="true"></i> Email</a>
+      <a class="btn btn--primary" href="https://www.linkedin.com/in/kiranshahi/" target="_blank" rel="noopener"><i class="fab fa-linkedin" aria-hidden="true"></i> LinkedIn</a>
+      <a class="btn btn--primary" href="https://github.com/kiranshahi" target="_blank" rel="noopener"><i class="fab fa-github" aria-hidden="true"></i> GitHub</a>
     </div>
     <p><a href="#site-footer">More contact options</a></p>
   </section>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -79,3 +79,18 @@
     transform: translateY(0);
   }
 }
+
+.connect__actions {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.connect__actions .btn {
+  transition: background-color 0.3s ease;
+}
+
+.connect__actions .btn:hover {
+  background-color: #2a5298;
+}


### PR DESCRIPTION
## Summary
- add Font Awesome icons to home page connect buttons with screen-reader friendly markup
- introduce `.connect__actions` flexbox layout with hover transitions

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c851d3848327ad988a57df4ad02c