### PR TITLE
style: update scholar and orcid icons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -76,11 +76,13 @@ footer:
       icon: "fab fa-linkedin"
       url: "https://www.linkedin.com/in/kiranshahi/"
     - label: "Google Scholar"
-      icon: "ai ai-google-scholar"
+      icon: "fa-brands fa-google-scholar"
       url: "https://scholar.google.com/citations?user=UY8GlccAAAAJ&hl=en"
+      color: "#4285F4"
     - label: "ORCID"
-      icon: "ai ai-orcid"
+      icon: "fab fa-orcid"
       url: "https://orcid.org/0000-0003-3739-5985"
+      color: "#A6CE39"
     # add any other external profiles here
 
 defaults:


### PR DESCRIPTION
## Summary
- use `fa-brands fa-google-scholar` icon and blue color for Google Scholar link
- add ORCID brand green and ensure icon uses `fab fa-orcid`

## Testing
- `bundle install` *(fails: 403 "Forbidden" from rubygems.org)*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a1cfeac054832783200aa0d4369c2c