### PR TITLE
feat: make home hero configurable

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,8 +5,8 @@ layout: default
 <div class="home">
   <section class="home-hero">
     <div class="page__hero text-center">
-      <h1 class="page__title">{{ site.author.name }}</h1>
-      <p class="page__lead">{{ site.author.bio }}</p>
+      <h1 class="page__title">{{ page.hero_title | default: page.title }}</h1>
+      <p class="page__lead">{{ page.hero_tagline | default: page.description }}</p>
       <div class="hero__actions">
         <a class="btn btn--primary btn--large" href="/research/">Research</a>
         <a class="btn btn--secondary btn--large" href="/contact/">Contact</a>

--- a/index.html
+++ b/index.html
@@ -6,4 +6,6 @@ title: "Kiran Shahi | AI Researcher, Computer Vision & Software Engineer"
 description: "Official website of Kiran Shahi — AI researcher in computer vision, video matting, and deep learning. Explore research papers, projects, and professional profiles."
 layout: home
 author_profile: true
+hero_title: "Kiran Shahi"
+hero_tagline: "AI Researcher, Computer Vision & Software Engineer"
 ---


### PR DESCRIPTION
## Summary
- use `page.hero_title` and `page.hero_tagline` in home layout
- add `hero_title` and `hero_tagline` front-matter fields to index

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d17c96d0832797d3258f078e236a