### PR TITLE
Remove custom JSON-LD schema from head include

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -15,28 +15,4 @@
 <meta name="twitter:title" content="{{ site.title }}">
 <meta name="twitter:description" content="{{ site.description | strip_newlines }}">
 <meta name="twitter:image" content="{{ '/assets/images/kiran-shahi.JPG' | relative_url }}">
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Person",
-  "name": "Kiran Shahi",
-  "url": "https://kirans.me",
-  "jobTitle": "AI Researcher & Software Engineer",
-  "alumniOf": {
-    "@type": "CollegeOrUniversity",
-    "name": "Brunel University London"
-  },
-  "sameAs": [
-    "https://dev.to/kiranshahi",
-    "https://scholar.google.com/citations?user=UY8GlccAAAAJ&hl=en",
-    "https://orcid.org/0000-0003-3739-5985",
-    "https://stackoverflow.com/users/5740382/kiran-shahi",
-    "https://www.linkedin.com/in/kiranshahi/",
-    "https://about.me/kiranshahi",
-    "https://www.kaggle.com/kiranshahi",
-    "https://github.com/kiranshahi",
-    "https://www.researchgate.net/profile/Kiran-Shahi"
-  ]
-}
-</script>
 {% endif %}


### PR DESCRIPTION
## Summary
- remove manual Person JSON-LD from custom head include to rely on auto-generated schema and avoid duplicate entries

## Testing
- `bundle install` *(fails: 403 Forbidden fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d3ffbe0483278e3e67e61d374b77