### PR TITLE
Ensure canonical URL uses trailing slash

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ description: "Kiran Shahi is a tech enthusiast who loves to solve real-world cha
 github_username: kiranshahi
 minimal_mistakes_skin: default
 search: true
+url: "https://kirans.me/"
 
 # Build settings
 markdown: kramdown
@@ -59,7 +60,7 @@ author:
   links:
     - label: "Website"
       icon: "fas fa-fw fa-link"
-      url: "https://kirans.me"
+      url: "https://kirans.me/"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
       url: "https://github.com/kiranshahi"


### PR DESCRIPTION
## Summary
- Add site `url` configuration and ensure Website link uses `https://kirans.me/`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `npx structured-data-testing-tool https://kirans.me/` *(fails: npm error 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d549c510832781ff430049022d56