### PR TITLE
Replace default JSON-LD with custom Person schema

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -120,13 +120,13 @@ comments:
     theme: "github-light" # "github-dark"
     issue_term: "pathname"
 repository: "kiranshahi/comments"
-
-social:
-  type:  "Person" # Person or Organization (defaults to Person)
-  name:  "Kiran Shahi" # If the user or organization name differs from the site's name
-  jobTitle: "Software Engineer"
-  links:
-    - "https://www.instagram.com/kirans.me/"
-    - "https://www.linkedin.com/in/kiranshahi/"
-    - "https://github.com/kiranshahi"
-    - "https://stackoverflow.com/users/5740382/kiran-shahi"
+jekyll_seo_tag: false
+# social:
+#   type:  "Person" # Person or Organization (defaults to Person)
+#   name:  "Kiran Shahi" # If the user or organization name differs from the site's name
+#   jobTitle: "Software Engineer"
+#   links:
+#     - "https://www.instagram.com/kirans.me/"
+#     - "https://www.linkedin.com/in/kiranshahi/"
+#     - "https://github.com/kiranshahi"
+#     - "https://stackoverflow.com/users/5740382/kiran-shahi"

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -16,3 +16,25 @@
 <meta name="twitter:description" content="{{ site.description | strip_newlines }}">
 <meta name="twitter:image" content="{{ '/assets/images/kiran-shahi.JPG' | relative_url }}">
 {% endif %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Kiran Shahi",
+  "url": "https://kirans.me/",
+  "image": "https://kirans.me/assets/images/kiran-shahi.JPG",
+  "jobTitle": "Software Engineer",
+  "alumniOf": {
+    "@type": "CollegeOrUniversity",
+    "name": "Brunel University"
+  },
+  "worksFor": {
+    "@type": "Organization",
+    "name": "Your Company"
+  },
+  "sameAs": [
+    "https://github.com/kiranshahi",
+    "https://www.linkedin.com/in/kiranshahi/"
+  ]
+}
+</script>


### PR DESCRIPTION
## Summary
- disable default `jekyll-seo-tag` JSON-LD output
- add custom `Person` JSON-LD definition in head

## Testing
- `bundle exec jekyll serve --detach` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a1d7183e188327bf44650ac283f5d0