### PR TITLE
feat: add theme toggle

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -6,6 +6,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2418700819447994"
      crossorigin="anonymous"></script>
 <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
+<script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
 
 {% if page.url == "/" %}
 <meta property="og:title" content="{{ site.title }}">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,10 +2,11 @@
 layout: default
 ---
 
-<div class="home">
-  <section class="home-hero">
-    <div class="page__hero text-center">
-      <h1 class="page__title">{{ page.hero_title | default: page.title }}</h1>
+  <div class="home">
+   <section class="home-hero">
+     <button id="theme-toggle" class="btn btn--secondary">Toggle Theme</button>
+     <div class="page__hero text-center">
+       <h1 class="page__title">{{ page.hero_title | default: page.title }}</h1>
       <p class="page__lead">{{ page.hero_tagline | default: page.description }}</p>
       <div class="hero__actions">
         <a class="btn btn--primary btn--large" href="/research/">Research</a>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,6 +1,20 @@
 :root {
   --color-primary: #2a5298;
   --color-secondary: #1e3c72;
+  --color-background: #ffffff;
+  --color-text: #000000;
+}
+
+[data-theme="dark"] {
+  --color-primary: #90b4ff;
+  --color-secondary: #6577c6;
+  --color-background: #121212;
+  --color-text: #f0f0f0;
+}
+
+body {
+  background-color: var(--color-background);
+  color: var(--color-text);
 }
 
 .featured-research {

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,20 @@
+(function () {
+  const html = document.documentElement;
+  const stored = localStorage.getItem('theme');
+  if (stored) {
+    html.setAttribute('data-theme', stored);
+  }
+
+  function toggleTheme() {
+    const current = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    html.setAttribute('data-theme', current);
+    localStorage.setItem('theme', current);
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    const toggle = document.getElementById('theme-toggle');
+    if (toggle) {
+      toggle.addEventListener('click', toggleTheme);
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add light/dark CSS variables and body color hooks
- toggle data-theme attribute with new `theme-toggle.js`
- include a theme switch button on home layout and reference script in head

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a1db6586b48327811f7049b9661c7f