### PR TITLE
Add focus outline for research cards

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -42,6 +42,10 @@ body {
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
 }
 
+.research-card:focus {
+  outline: 2px solid var(--color-primary);
+}
+
 .research-card__image {
   width: 100%;
   height: auto;


### PR DESCRIPTION
## Summary
- add focus outline to research card links for accessibility

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a1e1b6d6008327a7c915896c704ba2