### PR TITLE
Add sticky custom navigation header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,3 @@
+<header class="site-header">
+  {% include navigation.html %}
+</header>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,0 +1,27 @@
+<nav class="site-nav" role="navigation" aria-label="Primary Navigation">
+  <div class="nav-brand">
+    <a href="{{ '/' | relative_url }}">
+      <img class="nav-logo" src="{{ '/favicon-32x32.png' | relative_url }}" alt="{{ site.title }}">
+      <span>{{ site.title }}</span>
+    </a>
+  </div>
+  <button class="nav-toggle" aria-expanded="false" aria-controls="nav-menu">&#9776;</button>
+  <ul id="nav-menu" class="nav-menu">
+    {%- for item in site.data.navigation.main -%}
+      <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
+    {%- endfor -%}
+  </ul>
+</nav>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var toggle = document.querySelector('.nav-toggle');
+  var menu = document.getElementById('nav-menu');
+  if (toggle && menu) {
+    toggle.addEventListener('click', function() {
+      var expanded = this.getAttribute('aria-expanded') === 'true';
+      this.setAttribute('aria-expanded', !expanded);
+      menu.classList.toggle('active');
+    });
+  }
+});
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,13 @@
+---
+layout: null
+---
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: 'en' }}">
+  {% include head.html %}
+  <body>
+    {% include header.html %}
+    {{ content }}
+    {% include footer.html %}
+    {% include scripts.html %}
+  </body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -141,3 +141,63 @@ body {
     width: 100%;
   }
 }
+
+/* Navigation */
+.site-nav {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: var(--color-background);
+  border-bottom: 1px solid #e0e0e0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+}
+
+.nav-brand {
+  display: flex;
+  align-items: center;
+}
+
+.nav-brand .nav-logo {
+  height: 32px;
+  margin-right: 0.5rem;
+}
+
+.nav-toggle {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  cursor: pointer;
+  display: none;
+}
+
+.nav-menu {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-menu a {
+  text-decoration: none;
+  color: var(--color-text);
+}
+
+@media (max-width: 768px) {
+  .nav-toggle {
+    display: block;
+  }
+
+  .nav-menu {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .nav-menu.active {
+    display: flex;
+  }
+}


### PR DESCRIPTION
## Summary
- add custom navigation include with brand and responsive toggle
- wire header navigation into new default layout
- style navigation and make it sticky on scroll

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e27d5d148327a81d741f789bbeb6