### PR TITLE
Add theme toggle button with icon swapping

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -5,6 +5,7 @@
 <meta name="google-site-verification" content="Zds1YXaC6gE0uMFQVGFXVjXkXYc3OpEZzuSJE_oBQ-k" />
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2418700819447994"
      crossorigin="anonymous"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
 <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
 

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -11,6 +11,7 @@
       <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
     {%- endfor -%}
   </ul>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme"></button>
 </nav>
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,7 +4,6 @@ layout: default
 
   <div class="home">
    <section class="home-hero">
-     <button id="theme-toggle" class="btn btn--secondary">Toggle Theme</button>
      <div class="page__hero text-center">
        <h1 class="page__title">{{ page.hero_title | default: page.title }}</h1>
       <p class="page__lead">{{ page.hero_tagline | default: page.description }}</p>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -179,6 +179,15 @@ body {
   gap: 1rem;
   margin: 0;
   padding: 0;
+  margin-left: auto;
+}
+
+.theme-toggle {
+  margin-left: 1rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.25rem;
 }
 
 .nav-menu a {

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -5,16 +5,28 @@
     html.setAttribute('data-theme', stored);
   }
 
+  function setIcon(theme) {
+    const toggle = document.getElementById('theme-toggle');
+    if (toggle) {
+      toggle.innerHTML = theme === 'dark'
+        ? '<i class="fas fa-sun"></i>'
+        : '<i class="fas fa-moon"></i>';
+    }
+  }
+
   function toggleTheme() {
     const current = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
     html.setAttribute('data-theme', current);
     localStorage.setItem('theme', current);
+    setIcon(current);
   }
 
   document.addEventListener('DOMContentLoaded', function () {
     const toggle = document.getElementById('theme-toggle');
     if (toggle) {
       toggle.addEventListener('click', toggleTheme);
+      const theme = html.getAttribute('data-theme') || 'light';
+      setIcon(theme);
     }
   });
 })();


### PR DESCRIPTION
## Summary
- Move theme toggle into navigation bar
- Swap sun/moon icons based on current theme
- Style navigation toggle button and ensure Font Awesome icons load

## Testing
- `bundle exec jekyll serve` *(fails: bundler reported `command not found: jekyll`; `bundle install` failed with 403 Forbidden when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e6224b9c83279e53049e8261d417