### PR TITLE
feat: enhance theme toggle initialization

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -11,7 +11,7 @@
       <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
     {%- endfor -%}
   </ul>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme"></button>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme"><i class="fas fa-moon"></i></button>
 </nav>
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,9 +1,14 @@
 (function () {
   const html = document.documentElement;
-  const stored = localStorage.getItem('theme');
-  if (stored) {
-    html.setAttribute('data-theme', stored);
+  let theme = localStorage.getItem('theme');
+
+  if (!theme) {
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
   }
+
+  html.setAttribute('data-theme', theme);
 
   function setIcon(theme) {
     const toggle = document.getElementById('theme-toggle');
@@ -13,6 +18,8 @@
         : '<i class="fas fa-moon"></i>';
     }
   }
+
+  setIcon(theme);
 
   function toggleTheme() {
     const current = html.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
@@ -25,8 +32,6 @@
     const toggle = document.getElementById('theme-toggle');
     if (toggle) {
       toggle.addEventListener('click', toggleTheme);
-      const theme = html.getAttribute('data-theme') || 'light';
-      setIcon(theme);
     }
   });
 })();


### PR DESCRIPTION
## Summary
- set initial theme based on stored preference or system scheme and preload toggle icon
- add default icon to theme toggle button to prevent blank state

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a1e8c6534883279fd704820d664807