### PR TITLE
Refactor navigation script and improve accessibility

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
 <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
+<script src="{{ '/assets/js/navigation.js' | relative_url }}" defer></script>
 
 {% if page.url == "/" %}
 <meta property="og:title" content="{{ site.title }}">

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,23 +6,11 @@
     </a>
   </div>
   <button class="nav-toggle" aria-expanded="false" aria-controls="nav-menu">&#9776;</button>
-  <ul id="nav-menu" class="nav-menu">
+  <ul id="nav-menu" class="nav-menu" aria-hidden="true">
     {%- for item in site.data.navigation.main -%}
       <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
     {%- endfor -%}
   </ul>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme"><i class="fas fa-moon"></i></button>
 </nav>
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  var toggle = document.querySelector('.nav-toggle');
-  var menu = document.getElementById('nav-menu');
-  if (toggle && menu) {
-    toggle.addEventListener('click', function() {
-      var expanded = this.getAttribute('aria-expanded') === 'true';
-      this.setAttribute('aria-expanded', !expanded);
-      menu.classList.toggle('active');
-    });
-  }
-});
-</script>
+

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -201,12 +201,11 @@ body {
   }
 
   .nav-menu {
-    display: none;
     flex-direction: column;
     width: 100%;
   }
 
-  .nav-menu.active {
-    display: flex;
+  .nav-menu[aria-hidden='true'] {
+    display: none;
   }
 }

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -1,0 +1,48 @@
+(function () {
+  document.addEventListener('DOMContentLoaded', function () {
+    const toggle = document.querySelector('.nav-toggle');
+    const menu = document.getElementById('nav-menu');
+    if (!toggle || !menu) return;
+
+    const links = menu.querySelectorAll('a');
+
+    function isMobile() {
+      return window.getComputedStyle(toggle).display !== 'none';
+    }
+
+    function openMenu() {
+      toggle.setAttribute('aria-expanded', 'true');
+      menu.setAttribute('aria-hidden', 'false');
+      if (links.length) {
+        links[0].focus();
+      }
+    }
+
+    function closeMenu() {
+      toggle.setAttribute('aria-expanded', 'false');
+      menu.setAttribute('aria-hidden', 'true');
+      toggle.focus();
+    }
+
+    toggle.addEventListener('click', function () {
+      const expanded = this.getAttribute('aria-expanded') === 'true';
+      if (expanded) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
+    });
+
+    links.forEach(link => {
+      link.addEventListener('click', function () {
+        if (isMobile()) {
+          closeMenu();
+        }
+      });
+    });
+
+    if (!isMobile()) {
+      menu.setAttribute('aria-hidden', 'false');
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- extract mobile navigation logic to assets/js/navigation.js and load script with `defer`
- toggle `aria-hidden` on the nav menu and reset focus/expanded state on link click
- style mobile nav with `[aria-hidden]` attribute instead of `.active`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a1ea5ad22483278a081425262c3081