### PR TITLE
Switch theme toggle to Font Awesome 6 icons

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -11,6 +11,6 @@
       <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
     {%- endfor -%}
   </ul>
-  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme"><i class="fas fa-moon"></i></button>
+  <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme"><i class="fa-solid fa-moon"></i></button>
 </nav>
 

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -14,8 +14,8 @@
     const toggle = document.getElementById('theme-toggle');
     if (toggle) {
       toggle.innerHTML = theme === 'dark'
-        ? '<i class="fas fa-sun"></i>'
-        : '<i class="fas fa-moon"></i>';
+        ? '<i class="fa-solid fa-sun"></i>'
+        : '<i class="fa-solid fa-moon"></i>';
     }
   }
 


### PR DESCRIPTION
## Summary
- update navigation toggle button to use `fa-solid` icons
- switch theme toggle script to insert Font Awesome 6 icons when toggling

## Testing
- `node - <<'NODE'
const fs = require('fs');
const documentElement = {attrs:{}, setAttribute(k,v){this.attrs[k]=v;}, getAttribute(k){return this.attrs[k];}};
const button = {innerHTML:'', addEventListener(event,handler){this.handler=handler;}};
const document = {
  documentElement,
  getElementById(id){ if(id==='theme-toggle') return button; return null;},
  addEventListener(event,handler){ if(event==='DOMContentLoaded'){ handler(); }}
};
const window = { matchMedia: () => ({matches: false}) };
const localStorage = {store:{}, getItem(k){return this.store[k];}, setItem(k,v){this.store[k]=v;}};

Object.assign(global,{document, window, localStorage});
const script = fs.readFileSync('assets/js/theme-toggle.js','utf8');
require('vm').runInThisContext(script);
console.log('initial', button.innerHTML);
button.handler();
console.log('after click', button.innerHTML);
button.handler();
console.log('after second click', button.innerHTML);
NODE`
- `bundle exec jekyll build` (failed: bundler: command not found: jekyll)
- `bundle install` (failed: Gem::Net::HTTPClientException 403 "Forbidden")

------
https://chatgpt.com/codex/tasks/task_e_68a1f0bb23588327833faf87047324ef