### PR TITLE
Add custom head include

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,10 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {% seo %}
+  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+  <link rel="stylesheet" href="{{ '/assets/css/print.css' | relative_url }}" media="print">
+  {% include head/custom.html %}
+</head>


### PR DESCRIPTION
## Summary
- Override theme head to add custom scripts and structured data

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f2cc5c9483279802781e3247f2c2