### PR TITLE
Add build script and reference compiled CSS

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -6,7 +6,7 @@
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2418700819447994"
      crossorigin="anonymous"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
-<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
 <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/js/navigation.js' | relative_url }}" defer></script>
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+bundle exec jekyll build


### PR DESCRIPTION
## Summary
- add `build.sh` to run Jekyll build step
- ensure head template links to compiled CSS output

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `ls _site/assets/css` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f3ef65448327a1b0ae21bf178b98