### PR TITLE
style: add light and dark gradients to hero

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -72,14 +72,20 @@ body {
 
 /* Hero Section */
 .home-hero {
-  /* Gradient background without personal photo */
-  background: linear-gradient(135deg, var(--color-secondary), var(--color-primary));
-  color: var(--color-background);
+  /* Light theme gradient */
+  background:
+    radial-gradient(circle at top left, rgba(0, 0, 0, 0.05), transparent 40%),
+    radial-gradient(circle at bottom right, rgba(0, 0, 0, 0.05), transparent 40%),
+    linear-gradient(135deg, #ffffff 0%, #e0eaff 100%);
+  color: var(--color-text);
   padding: 6rem 1rem;
 }
 
 [data-theme="dark"] .home-hero {
-  color: var(--color-text);
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.05), transparent 40%),
+    radial-gradient(circle at bottom right, rgba(255, 255, 255, 0.05), transparent 40%),
+    linear-gradient(135deg, #0f2027 0%, #203a43 50%, #2c5364 100%);
 }
 
 .home-hero .page__title {


### PR DESCRIPTION
## Summary
- adjust hero section with separate light and dark gradients for clearer theming

## Testing
- `bundle exec jekyll build` (fails: bundler: command not found: jekyll)

------
https://chatgpt.com/codex/tasks/task_e_68a1f69af6448327bab28baa07107220