### PR TITLE
Remove navigation borders from styles

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -163,7 +163,6 @@ body {
   top: 0;
   z-index: 1000;
   background: var(--color-background);
-  border-bottom: 1px solid var(--color-text);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -222,8 +221,6 @@ body {
     flex-direction: column;
     width: 100%;
     background: var(--color-background);
-    border-top: 1px solid var(--color-text);
-    border-bottom: 1px solid var(--color-text);
   }
 
   .nav-menu li {


### PR DESCRIPTION
## Summary
- remove bottom border from sticky site nav
- drop mobile menu borders for cleaner layout

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a1fadec16c8327b91f6a313750bd3a