### PR TITLE
refine research card styling

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -35,16 +35,17 @@ body {
 .research-card {
   display: block;
   padding: 1.5rem;
-  border: 1px solid var(--color-text);
   border-radius: 8px;
   background: var(--color-background);
   text-decoration: none;
   color: inherit;
-  transition: box-shadow 0.2s ease-in-out;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  transition: box-shadow 0.2s ease-in-out, transform 0.2s ease-in-out;
 }
 
 .research-card:hover {
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
 }
 
 .research-card:focus {


### PR DESCRIPTION
## Summary
- remove hard border from research cards, add subtle default shadow and transition
- boost hover effect with stronger shadow and slight lift

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden" when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fbed9e548327a32b212fd599e0d6