### PR TITLE
Improve navigation accessibility for mobile and desktop

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -5,8 +5,8 @@
       <span>{{ site.title }}</span>
     </a>
   </div>
-  <button class="nav-toggle" aria-expanded="false" aria-controls="nav-menu">&#9776;</button>
-  <ul id="nav-menu" class="nav-menu" aria-hidden="true">
+  <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-menu">&#9776;</button>
+  <ul id="nav-menu" class="nav-menu" aria-hidden="false">
     {%- for item in site.data.navigation.main -%}
       <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
     {%- endfor -%}

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -13,7 +13,9 @@
 
     function openMenu() {
       toggle.setAttribute('aria-expanded', 'true');
-      menu.setAttribute('aria-hidden', 'false');
+      if (isMobile()) {
+        menu.setAttribute('aria-hidden', 'false');
+      }
       if (links.length) {
         links[0].focus();
       }
@@ -21,7 +23,9 @@
 
     function closeMenu() {
       toggle.setAttribute('aria-expanded', 'false');
-      menu.setAttribute('aria-hidden', 'true');
+      if (isMobile()) {
+        menu.setAttribute('aria-hidden', 'true');
+      }
       toggle.focus();
     }
 
@@ -65,7 +69,9 @@
       }
     });
 
-    if (!isMobile()) {
+    if (isMobile()) {
+      menu.setAttribute('aria-hidden', 'true');
+    } else {
       menu.setAttribute('aria-hidden', 'false');
     }
   });


### PR DESCRIPTION
## Summary
- add aria-label to navigation toggle and expose menu by default
- restrict aria-hidden toggling to mobile viewports so assistive tech can always access the menu

## Testing
- `./build.sh` *(fails: bundler: command not found)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a1fe1193f8832786b7a242af0c9f81