### PR TITLE
Add hero sections to static pages

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,0 +1,10 @@
+{% if page.hero_title or page.hero_tagline %}
+<section class="home-hero">
+  <div class="page__hero text-center">
+    <h1 class="page__title">{{ page.hero_title | default: page.title }}</h1>
+    {% if page.hero_tagline %}
+    <p class="page__lead">{{ page.hero_tagline }}</p>
+    {% endif %}
+  </div>
+</section>
+{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,8 @@
+---
+layout: default
+---
+
+<div class="page">
+  {% include hero.html %}
+  {{ content }}
+</div>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,6 +1,10 @@
 ---
 permalink: /about/
 title: "About"
+layout: page
+hero_title: "About Me"
+hero_tagline: "Software Engineer & AI Enthusiast"
+author_profile: true
 ---
 👋 Hello, I'm Kiran Shahi, a software engineer from Pokhara, Nepal.
 

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -1,7 +1,10 @@
 ---
 title: "Contact"
-layout: single
+layout: page
 permalink: /contact/
+hero_title: "Get in Touch"
+hero_tagline: "Let's collaborate or just say hello"
+author_profile: true
 ---
 
 I'm always happy to connect with fellow developers, researchers, and collaborators.

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,7 +1,10 @@
 ---
 title: "Research"
-layout: single
+layout: page
 permalink: /research/
+hero_title: "Research"
+hero_tagline: "Exploring Deep Learning & Computer Vision"
+author_profile: true
 ---
 
 My research focuses on applying deep learning and computer vision to solve real-world problems.


### PR DESCRIPTION
## Summary
- add reusable `hero.html` include and `page` layout
- add hero metadata to About, Research, and Contact pages

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a20168e0b483278f291e907f7d6e46