### PR TITLE
fix: ensure theme toggle icon color adapts to theme

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -203,6 +203,7 @@ body {
   border: none;
   cursor: pointer;
   font-size: 1.25rem;
+  color: var(--color-text);
 }
 
 .nav-menu a {


### PR DESCRIPTION
## Summary
- ensure theme toggle icon color uses current text color so it's visible in both light and dark modes

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a203e23ee8832795b1932cbddb4386