### PR TITLE
Reorder navbar icons

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -5,12 +5,12 @@
       <span>{{ site.title }}</span>
     </a>
   </div>
-  <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-menu">&#9776;</button>
   <ul id="nav-menu" class="nav-menu" aria-hidden="false">
     {%- for item in site.data.navigation.main -%}
       <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
     {%- endfor -%}
   </ul>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme"><i class="fa-solid fa-moon"></i></button>
+  <button class="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="nav-menu">&#9776;</button>
 </nav>
 


### PR DESCRIPTION
## Summary
- reorder navigation include so theme toggle precedes nav toggle

## Testing
- `./build.sh` (fails: bundler could not find jekyll)
- `bundle install` (fails: Gem::Net::HTTPClientException 403 "Forbidden")

------
https://chatgpt.com/codex/tasks/task_e_68a2054def848327b96a4a5f3a997aed