### PR TITLE
Add copy email button with clipboard feedback

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -11,8 +11,9 @@ I'm always happy to connect with fellow developers, researchers, and collaborato
 
 <div class="contact-item">
   <span class="contact-icon"><i class="fas fa-envelope"></i></span>
-  <a id="email-link" class="contact-link" href="#">****</a>
-  <button id="reveal-email">Show Email</button>
+  <span id="email-address" class="contact-link">****</span>
+  <button id="copy-email" class="copy-email-btn">Copy Email</button>
+  <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
 </div>
 <div class="contact-item">
   <span class="contact-icon"><i class="fab fa-linkedin"></i></span>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -268,3 +268,23 @@ body {
   color: var(--color-primary);
   text-decoration: underline;
 }
+
+.copy-email-btn {
+  background: var(--color-primary);
+  color: var(--color-background);
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.copy-email-btn.copied {
+  background: var(--color-secondary);
+}
+
+.copy-feedback {
+  margin-left: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--color-primary);
+}

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,13 +1,24 @@
 (function () {
   document.addEventListener('DOMContentLoaded', function () {
-    const btn = document.getElementById('reveal-email');
-    const link = document.getElementById('email-link');
-    if (btn && link) {
+    const btn = document.getElementById('copy-email');
+    const span = document.getElementById('email-address');
+    const feedback = document.getElementById('copy-feedback');
+    if (btn && span) {
       btn.addEventListener('click', function () {
         const email = 'kiran.shahi.c3@gmail.com';
-        link.textContent = email;
-        link.href = 'mailto:' + email;
-        btn.remove();
+        span.textContent = email;
+        navigator.clipboard.writeText(email).then(function () {
+          if (feedback) {
+            feedback.textContent = 'Copied!';
+          }
+          btn.classList.add('copied');
+          setTimeout(function () {
+            btn.classList.remove('copied');
+            if (feedback) {
+              feedback.textContent = '';
+            }
+          }, 2000);
+        });
       });
     }
   });


### PR DESCRIPTION
## Summary
- Add "Copy Email" button on contact page and aria-live feedback span
- Enable clipboard copying and feedback message via JavaScript
- Style copy button states and feedback message

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*
- `bundle install` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a207ffd0d483279533bd7471cf33e3