### PR TITLE
style: enhance social links

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -15,13 +15,14 @@ I'm always happy to connect with fellow developers, researchers, and collaborato
   <button id="copy-email" class="copy-email-btn">Copy Email</button>
   <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
 </div>
-<div class="contact-item">
-  <span class="contact-icon"><i class="fab fa-linkedin"></i></span>
-  <a class="contact-link" href="https://www.linkedin.com/in/kiranshahi/">linkedin.com/in/kiranshahi</a>
+
+<div class="social-link">
+  <i class="fab fa-linkedin" aria-hidden="true"></i>
+  <a href="https://www.linkedin.com/in/kiranshahi/">linkedin.com/in/kiranshahi</a>
 </div>
-<div class="contact-item">
-  <span class="contact-icon"><i class="fab fa-github"></i></span>
-  <a class="contact-link" href="https://github.com/kiranshahi">github.com/kiranshahi</a>
+<div class="social-link">
+  <i class="fab fa-github" aria-hidden="true"></i>
+  <a href="https://github.com/kiranshahi">github.com/kiranshahi</a>
 </div>
 
 Feel free to reach out with questions, ideas, or just to say hello.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -288,3 +288,28 @@ body {
   font-size: 0.9rem;
   color: var(--color-primary);
 }
+
+.social-link {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.1rem;
+  margin-bottom: 0.75rem;
+}
+
+.social-link i {
+  color: var(--color-primary);
+  font-size: 1.25rem;
+}
+
+.social-link a {
+  color: var(--color-text);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.social-link a:hover,
+.social-link a:focus {
+  color: var(--color-primary);
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- wrap LinkedIn and GitHub references in `.social-link` containers with icons
- style `.social-link` elements for clearer spacing and interactive hover states

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: 403 Forbidden when fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a2095a28748327ba3408b77bd9b6e1