### PR TITLE
Add responsive contact section wrapper

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -9,20 +9,22 @@ author_profile: true
 
 I'm always happy to connect with fellow developers, researchers, and collaborators.
 
-<div class="contact-item">
-  <span class="contact-icon"><i class="fas fa-envelope"></i></span>
-  <span id="email-address" class="contact-link">****</span>
-  <button id="copy-email" class="copy-email-btn">Copy Email</button>
-  <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
-</div>
+<div class="contact-section">
+  <div class="contact-item">
+    <span class="contact-icon"><i class="fas fa-envelope"></i></span>
+    <span id="email-address" class="contact-link">****</span>
+    <button id="copy-email" class="copy-email-btn">Copy Email</button>
+    <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
+  </div>
 
-<div class="social-link">
-  <i class="fab fa-linkedin" aria-hidden="true"></i>
-  <a href="https://www.linkedin.com/in/kiranshahi/">linkedin.com/in/kiranshahi</a>
-</div>
-<div class="social-link">
-  <i class="fab fa-github" aria-hidden="true"></i>
-  <a href="https://github.com/kiranshahi">github.com/kiranshahi</a>
+  <div class="social-link">
+    <i class="fab fa-linkedin" aria-hidden="true"></i>
+    <a href="https://www.linkedin.com/in/kiranshahi/">linkedin.com/in/kiranshahi</a>
+  </div>
+  <div class="social-link">
+    <i class="fab fa-github" aria-hidden="true"></i>
+    <a href="https://github.com/kiranshahi">github.com/kiranshahi</a>
+  </div>
 </div>
 
 Feel free to reach out with questions, ideas, or just to say hello.

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -246,6 +246,27 @@ body {
   padding: 1rem;
 }
 
+.contact-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+@media (min-width: 600px) {
+  .contact-section {
+    padding: 1.5rem 2rem;
+  }
+}
+
+@media (min-width: 900px) {
+  .contact-section {
+    flex-direction: row;
+    flex-wrap: wrap;
+    padding: 2rem 3rem;
+  }
+}
+
 .contact-item {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- wrap contact elements in a new `.contact-section`
- add responsive padding and layout rules for `.contact-section`

## Testing
- `bundle exec jekyll build` *(fails: "bundler: command not found: jekyll")*
- `bundle install` *(fails: 403 Forbidden fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a20a4a4b84832782b0f2ccc91f1a29