### PR TITLE
Add accessible mailto link on contact page

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -14,8 +14,17 @@ author_profile: true
     <div class="contact-section">
       <div class="contact-item">
         <span class="contact-icon"><i class="fas fa-envelope"></i></span>
-        <span id="email-address" class="contact-link">****</span>
-        <button id="copy-email" class="copy-email-btn">Copy Email</button>
+        <a id="email-address"
+           class="contact-link"
+           href="mailto:kiran.shahi.c3@gmail.com"
+           aria-label="Email kiran.shahi.c3@gmail.com"
+           data-email="kiran.shahi.c3@gmail.com">****</a>
+        <noscript>
+          <a class="contact-link"
+             href="mailto:kiran.shahi.c3@gmail.com"
+             aria-label="Email kiran.shahi.c3@gmail.com">kiran.shahi.c3@gmail.com</a>
+        </noscript>
+        <button id="copy-email" class="copy-email-btn" aria-label="Copy email address">Copy Email</button>
         <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
       </div>
 

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -1,12 +1,13 @@
 (function () {
   document.addEventListener('DOMContentLoaded', function () {
     const btn = document.getElementById('copy-email');
-    const span = document.getElementById('email-address');
+    const link = document.getElementById('email-address');
     const feedback = document.getElementById('copy-feedback');
-    if (btn && span) {
+    if (btn && link) {
       btn.addEventListener('click', function () {
-        const email = 'kiran.shahi.c3@gmail.com';
-        span.textContent = email;
+        const email = link.getAttribute('data-email') || 'kiran.shahi.c3@gmail.com';
+        link.textContent = email;
+        link.href = 'mailto:' + email;
         navigator.clipboard.writeText(email).then(function () {
           if (feedback) {
             feedback.textContent = 'Copied!';


### PR DESCRIPTION
## Summary
- Replace obfuscated email span with accessible mailto link and noscript fallback
- Update copy-email script to handle link and set mailto target
- Add aria-label for copy email button

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a20d50b7788327a6c3e578cc8dc625