### PR TITLE
Handle clipboard availability in contact form

### DIFF
--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -3,23 +3,52 @@
     const btn = document.getElementById('copy-email');
     const link = document.getElementById('email-address');
     const feedback = document.getElementById('copy-feedback');
+
+    function manualCopy(message) {
+      if (feedback) {
+        feedback.textContent = message;
+      }
+      if (document.createRange && window.getSelection) {
+        const range = document.createRange();
+        range.selectNodeContents(link);
+        const selection = window.getSelection();
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+      setTimeout(function () {
+        if (window.getSelection) {
+          window.getSelection().removeAllRanges();
+        }
+        if (feedback) {
+          feedback.textContent = '';
+        }
+      }, 2000);
+    }
+
     if (btn && link) {
       btn.addEventListener('click', function () {
         const email = link.getAttribute('data-email') || 'kiran.shahi.c3@gmail.com';
         link.textContent = email;
         link.href = 'mailto:' + email;
-        navigator.clipboard.writeText(email).then(function () {
-          if (feedback) {
-            feedback.textContent = 'Copied!';
-          }
-          btn.classList.add('copied');
-          setTimeout(function () {
-            btn.classList.remove('copied');
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(email).then(function () {
             if (feedback) {
-              feedback.textContent = '';
+              feedback.textContent = 'Copied!';
             }
-          }, 2000);
-        });
+            btn.classList.add('copied');
+            setTimeout(function () {
+              btn.classList.remove('copied');
+              if (feedback) {
+                feedback.textContent = '';
+              }
+            }, 2000);
+          }).catch(function () {
+            manualCopy('Copy failed. Press Ctrl+C to copy.');
+          });
+        } else {
+          manualCopy('Press Ctrl+C to copy.');
+        }
       });
     }
   });


### PR DESCRIPTION
## Summary
- Gracefully handle clipboard copy operations on the contact page
- Provide manual selection fallback when clipboard access fails or is unavailable

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a20e65aecc83278a7c35255669d68e