### PR TITLE
Add focus styles for contact link and email button

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -311,9 +311,15 @@ body {
   transition: color 0.2s ease;
 }
 
-.contact-link:hover {
+.contact-link:hover,
+.contact-link:focus {
   color: var(--color-primary);
   text-decoration: underline;
+}
+
+.contact-link:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
 }
 
 .copy-email-btn {
@@ -324,6 +330,16 @@ body {
   border-radius: 4px;
   cursor: pointer;
   transition: background 0.2s ease;
+}
+
+.copy-email-btn:hover,
+.copy-email-btn:focus {
+  background: var(--color-secondary);
+}
+
+.copy-email-btn:focus-visible {
+  outline: 2px solid var(--color-text);
+  outline-offset: 2px;
 }
 
 .copy-email-btn.copied {


### PR DESCRIPTION
## Summary
- Add focus and focus-visible styles for `.contact-link`
- Enhance `.copy-email-btn` with hover/focus styling and visible focus outline

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a20f8355888327ae86836f9e0e6616