### PR TITLE
Align contact links horizontally

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -22,13 +22,12 @@ author_profile: true
     <button id="copy-email" class="copy-email-btn" aria-label="Copy email address">Copy Email</button>
     <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
   </div>
-
-  <div class="social-link">
-    <i class="fab fa-linkedin" aria-hidden="true"></i>
+  <div class="contact-item">
+    <span class="contact-icon"><i class="fab fa-linkedin" aria-hidden="true"></i></span>
     <a href="https://www.linkedin.com/in/kiranshahi/" target="_blank" rel="noopener noreferrer" aria-label="Open LinkedIn profile in new tab">linkedin.com/in/kiranshahi</a>
   </div>
-  <div class="social-link">
-    <i class="fab fa-github" aria-hidden="true"></i>
+  <div class="contact-item">
+    <span class="contact-icon"><i class="fab fa-github" aria-hidden="true"></i></span>
     <a href="https://github.com/kiranshahi" target="_blank" rel="noopener noreferrer" aria-label="Open GitHub profile in new tab">github.com/kiranshahi</a>
   </div>
 </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -163,6 +163,20 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 2rem;
+  /* Light theme gradient */
+  background:
+    radial-gradient(circle at top left, rgba(0, 0, 0, 0.05), transparent 40%),
+    radial-gradient(circle at bottom right, rgba(0, 0, 0, 0.05), transparent 40%),
+    linear-gradient(135deg, #ffffff 0%, #e0eaff 100%);
+  color: var(--color-text);
+  padding: 6rem 1rem;
+}
+
+[data-theme="dark"] .contact-hero {
+  background:
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.05), transparent 40%),
+    radial-gradient(circle at bottom right, rgba(255, 255, 255, 0.05), transparent 40%),
+    linear-gradient(135deg, #0f2027 0%, #203a43 50%, #2c5364 100%);
 }
 
 .contact-hero__text {
@@ -274,21 +288,23 @@ body {
 
 .contact-section {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 1rem;
   padding: 1rem;
 }
 
 @media (min-width: 600px) {
   .contact-section {
+    gap: 1.5rem;
     padding: 1.5rem 2rem;
   }
 }
 
 @media (min-width: 900px) {
   .contact-section {
-    flex-direction: row;
-    flex-wrap: wrap;
+    gap: 2rem;
     padding: 2rem 3rem;
   }
 }
@@ -297,7 +313,6 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-bottom: 0.75rem;
 }
 
 .contact-icon {
@@ -352,27 +367,3 @@ body {
   color: var(--color-primary);
 }
 
-.social-link {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 1.1rem;
-  margin-bottom: 0.75rem;
-}
-
-.social-link i {
-  color: var(--color-primary);
-  font-size: 1.25rem;
-}
-
-.social-link a {
-  color: var(--color-text);
-  text-decoration: none;
-  transition: color 0.2s ease;
-}
-
-.social-link a:hover,
-.social-link a:focus {
-  color: var(--color-primary);
-  text-decoration: underline;
-}


### PR DESCRIPTION
## Summary
- Display email, LinkedIn, and GitHub side by side on the contact page
- Match contact page hero background to the home page gradient

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*
- `bundle install` *(fails: 403 Forbidden fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_68a2131f1ac08327a0182166362d840b