### PR TITLE
Add contact form with validation and styling

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -32,4 +32,18 @@ author_profile: true
   </div>
 </div>
 
+<form class="contact-form" action="https://formspree.io/f/your-form-id" method="POST">
+  <label for="name">Name</label>
+  <input type="text" id="name" name="name" required>
+
+  <label for="email">Email</label>
+  <input type="email" id="email" name="email" required>
+
+  <label for="message">Message</label>
+  <textarea id="message" name="message" required></textarea>
+
+  <button type="submit">Send</button>
+  <p class="form-status" aria-live="polite"></p>
+</form>
+
 <script src="{{ '/assets/js/contact.js' | relative_url }}" defer></script>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -367,3 +367,49 @@ body {
   color: var(--color-primary);
 }
 
+.contact-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 600px;
+  margin: 2rem auto;
+}
+
+.contact-form label {
+  font-weight: 600;
+}
+
+.contact-form input,
+.contact-form textarea {
+  padding: 0.5rem;
+  border: 1px solid var(--color-primary);
+  border-radius: 4px;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.contact-form button {
+  align-self: flex-start;
+  background: var(--color-primary);
+  color: var(--color-background);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.contact-form button:hover,
+.contact-form button:focus {
+  background: var(--color-secondary);
+}
+
+.form-status {
+  font-size: 0.9rem;
+  color: var(--color-primary);
+}
+
+.form-status.error {
+  color: #d9534f;
+}
+

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -51,5 +51,55 @@
         }
       });
     }
+
+    const form = document.querySelector('.contact-form');
+    if (form) {
+      const status = form.querySelector('.form-status');
+      form.addEventListener('submit', async function (e) {
+        e.preventDefault();
+        if (status) {
+          status.textContent = '';
+          status.classList.remove('error');
+        }
+        const name = form.querySelector('input[name="name"]').value.trim();
+        const email = form.querySelector('input[name="email"]').value.trim();
+        const message = form.querySelector('textarea[name="message"]').value.trim();
+        if (!name || !email || !message) {
+          if (status) {
+            status.textContent = 'Please fill in all fields.';
+            status.classList.add('error');
+          }
+          return;
+        }
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailPattern.test(email)) {
+          if (status) {
+            status.textContent = 'Please enter a valid email address.';
+            status.classList.add('error');
+          }
+          return;
+        }
+        try {
+          const response = await fetch(form.action, {
+            method: form.method,
+            headers: { 'Accept': 'application/json' },
+            body: new FormData(form)
+          });
+          if (response.ok) {
+            if (status) {
+              status.textContent = 'Thanks for your message!';
+            }
+            form.reset();
+          } else {
+            throw new Error('Network response was not ok');
+          }
+        } catch (error) {
+          if (status) {
+            status.textContent = 'Oops! There was a problem submitting your form.';
+            status.classList.add('error');
+          }
+        }
+      });
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- add contact form with labels for name, email, and message
- style form fields and button using theme variables
- extend contact script to validate form and show submission feedback

## Testing
- `bash build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a215b8b12483279eeb6d57c831a02c