### PR TITLE
style: improve contact section layout

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -290,15 +290,14 @@ ul.contact-section {
   list-style: none;
   margin: 0;
   padding: 1rem;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: 1fr;
   gap: 1rem;
 }
 
 @media (min-width: 600px) {
   ul.contact-section {
+    grid-template-columns: repeat(2, 1fr);
     gap: 1.5rem;
     padding: 1.5rem 2rem;
   }
@@ -306,6 +305,7 @@ ul.contact-section {
 
 @media (min-width: 900px) {
   ul.contact-section {
+    grid-template-columns: repeat(3, 1fr);
     gap: 2rem;
     padding: 2rem 3rem;
   }
@@ -315,6 +315,10 @@ li.contact-item {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  padding: 1rem;
+  border: 1px solid var(--color-primary);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .contact-icon {


### PR DESCRIPTION
## Summary
- switch `.contact-section` to a responsive CSS grid for 1–3 column layouts
- add padding, borders, and subtle shadows to `.contact-item` for card-like appearance

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a21874df108327aef6620841bca898