### PR TITLE
feat: make contact items full width

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -295,35 +295,29 @@ ul.contact-section {
   gap: 1rem;
 }
 
-@media (min-width: 600px) {
-  ul.contact-section {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1.5rem;
-    padding: 1.5rem 2rem;
-  }
-}
-
-@media (min-width: 900px) {
-  ul.contact-section {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 2rem;
-    padding: 2rem 3rem;
-  }
-}
+/* Removed responsive grid columns for full-width contact items */
 
 li.contact-item {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 1rem;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  width: 100%;
   border: 1px solid var(--color-primary);
   border-radius: 8px;
+  background: var(--color-background);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+li.contact-item:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transform: translateY(-2px);
 }
 
 .contact-icon {
   color: var(--color-primary);
-  font-size: 1.25rem;
+  font-size: 1.75rem;
 }
 
 .contact-link {


### PR DESCRIPTION
## Summary
- drop responsive multi-column grid for `ul.contact-section`
- give contact items modern card styling with hover elevation
- enlarge contact icons for better legibility

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a21eb41ab08327a5a05538d95ebfa2