### PR TITLE
Revamp contact page UI with contact details

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -6,32 +6,33 @@ hero_title: "Get in Touch"
 hero_tagline: "Let's collaborate or just say hello"
 author_profile: true
 ---
-<address>
-  <ul class="contact-section">
-    <li class="contact-item">
-      <span class="contact-icon"><i class="fas fa-envelope" aria-hidden="true"></i></span>
-      <a id="email-address"
-         class="contact-link"
-         href="mailto:kiran.shahi.c3@gmail.com"
-         aria-label="Email kiran.shahi.c3@gmail.com"
-         data-email="kiran.shahi.c3@gmail.com">****</a>
-      <noscript>
-        <a class="contact-link"
-           href="mailto:kiran.shahi.c3@gmail.com"
-           aria-label="Email kiran.shahi.c3@gmail.com">kiran.shahi.c3@gmail.com</a>
-      </noscript>
-      <button id="copy-email" class="copy-email-btn" aria-label="Copy email address">Copy Email</button>
-      <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
-    </li>
-    <li class="contact-item">
-      <span class="contact-icon"><i class="fab fa-linkedin" aria-hidden="true"></i></span>
-      <a href="https://www.linkedin.com/in/kiranshahi/" target="_blank" rel="noopener noreferrer" aria-label="Open LinkedIn profile in new tab">linkedin.com/in/kiranshahi</a>
-    </li>
-    <li class="contact-item">
-      <span class="contact-icon"><i class="fab fa-github" aria-hidden="true"></i></span>
-      <a href="https://github.com/kiranshahi" target="_blank" rel="noopener noreferrer" aria-label="Open GitHub profile in new tab">github.com/kiranshahi</a>
-    </li>
-  </ul>
-</address>
+<div class="contact-details">
+  <div class="contact-card">
+    <span class="contact-icon"><i class="fas fa-envelope" aria-hidden="true"></i></span>
+    <a id="email-address"
+       class="contact-link"
+       href="mailto:kiran.shahi.c3@gmail.com"
+       aria-label="Email kiran.shahi.c3@gmail.com"
+       data-email="kiran.shahi.c3@gmail.com">kiran.shahi.c3@gmail.com</a>
+    <button id="copy-email" class="copy-email-btn" aria-label="Copy email address">Copy Email</button>
+    <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
+  </div>
+  <div class="contact-card">
+    <span class="contact-icon"><i class="fab fa-linkedin" aria-hidden="true"></i></span>
+    <a class="contact-link"
+       href="https://www.linkedin.com/in/kiranshahi/"
+       target="_blank"
+       rel="noopener noreferrer"
+       aria-label="Open LinkedIn profile in new tab">linkedin.com/in/kiranshahi</a>
+  </div>
+  <div class="contact-card">
+    <span class="contact-icon"><i class="fab fa-github" aria-hidden="true"></i></span>
+    <a class="contact-link"
+       href="https://github.com/kiranshahi"
+       target="_blank"
+       rel="noopener noreferrer"
+       aria-label="Open GitHub profile in new tab">github.com/kiranshahi</a>
+  </div>
+</div>
 
 <script src="{{ '/assets/js/contact.js' | relative_url }}" defer></script>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -286,23 +286,18 @@ body {
   padding: 1rem;
 }
 
-ul.contact-section {
-  list-style: none;
-  margin: 0;
-  padding: 1rem;
+.contact-details {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1rem;
+  padding: 1rem;
 }
 
-/* Removed responsive grid columns for full-width contact items */
-
-li.contact-item {
+.contact-card {
   display: flex;
   align-items: center;
   gap: 0.75rem;
   padding: 1.5rem;
-  width: 100%;
   border: 1px solid var(--color-primary);
   border-radius: 8px;
   background: var(--color-background);
@@ -310,7 +305,7 @@ li.contact-item {
   transition: box-shadow 0.3s ease, transform 0.3s ease;
 }
 
-li.contact-item:hover {
+.contact-card:hover {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   transform: translateY(-2px);
 }


### PR DESCRIPTION
## Summary
- Restyle contact page with card-based layout for email, LinkedIn, and GitHub links
- Introduce responsive contact page grid and card styles

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a21fdae09483279182f87e512918e8