### PR TITLE
feat: integrate inter font

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -5,6 +5,7 @@
 <meta name="google-site-verification" content="Zds1YXaC6gE0uMFQVGFXVjXkXYc3OpEZzuSJE_oBQ-k" />
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2418700819447994"
      crossorigin="anonymous"></script>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
 <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -20,6 +20,24 @@
 body {
   background-color: var(--color-background);
   color: var(--color-text);
+  font-family: 'Inter', sans-serif;
+}
+
+h1 {
+  font-weight: 700;
+}
+
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 600;
+}
+
+button,
+.btn {
+  font-weight: 600;
 }
 
 .featured-research {
@@ -63,6 +81,7 @@ body {
 .research-card__title {
   margin: 0 0 0.5rem;
   font-size: 1.25rem;
+  font-weight: 600;
 }
 
 .research-card__summary {
@@ -360,6 +379,7 @@ body {
   border-radius: 4px;
   cursor: pointer;
   transition: background 0.2s ease;
+  font-weight: 600;
 }
 
 .copy-email-btn:hover,


### PR DESCRIPTION
## Summary
- load Inter font from Google Fonts
- apply Inter site-wide and refine heading/button weights
- retain accessible dark mode colors

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a22ad4043c8327b662f1ce6ca0200e