### PR TITLE
Enhance navigation styling with active link highlighting

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -7,7 +7,7 @@
   </div>
   <ul id="nav-menu" class="nav-menu" aria-hidden="false">
     {%- for item in site.data.navigation.main -%}
-      <li><a href="{{ item.url | relative_url }}">{{ item.title }}</a></li>
+      <li><a href="{{ item.url | relative_url }}" class="{% if page.url == item.url or page.url contains item.url %}active{% endif %}">{{ item.title }}</a></li>
     {%- endfor -%}
   </ul>
   <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme"><i class="fa-solid fa-moon"></i></button>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -236,6 +236,7 @@ button,
   align-items: center;
   justify-content: space-between;
   padding: 0.5rem 1rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .nav-brand {
@@ -275,8 +276,31 @@ button,
 }
 
 .nav-menu a {
+  display: inline-block;
+  padding: 0.5rem 0.75rem;
   text-decoration: none;
   color: var(--color-text);
+  border-bottom: 2px solid transparent;
+  border-radius: 4px;
+  transition: color 0.3s ease, background-color 0.3s ease, border-color 0.3s ease;
+}
+
+.nav-menu a:hover {
+  color: var(--color-primary);
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+.nav-menu a.active {
+  color: var(--color-primary);
+  border-bottom-color: var(--color-primary);
+}
+
+[data-theme="dark"] .site-nav {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="dark"] .nav-menu a:hover {
+  background-color: rgba(255, 255, 255, 0.1);
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- add subtle bottom border to nav bar and refine spacing and hover styles
- highlight current page in navigation
- mirror navigation enhancements in dark mode

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a22c9f05fc8327bdb6558b3d8edaa8