### PR TITLE
Preserve envelope icon when revealing contact email

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -14,7 +14,7 @@ author_profile: true
        aria-label="Email kiran.shahi.c3@gmail.com"
        data-email="kiran.shahi.c3@gmail.com">
       <span class="contact-icon"><i class="fas fa-envelope" aria-hidden="true"></i></span>
-      kir***.sha**.**@gmail.com
+      <span id="email-text">kir***.sha**.**@gmail.com</span>
     </a>
     <button id="copy-email" class="copy-email-btn" aria-label="Reveal email address">Reveal Email</button>
     <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -2,6 +2,7 @@
   document.addEventListener('DOMContentLoaded', function () {
     const btn = document.getElementById('copy-email');
     const link = document.getElementById('email-address');
+    const emailText = document.getElementById('email-text');
     const feedback = document.getElementById('copy-feedback');
     let revealed = false;
 
@@ -31,7 +32,9 @@
         const email = link.getAttribute('data-email') || 'kiran.shahi.c3@gmail.com';
 
         if (!revealed) {
-          link.textContent = email;
+          if (emailText) {
+            emailText.textContent = email;
+          }
           link.href = 'mailto:' + email;
           btn.textContent = 'Copy Email';
           btn.setAttribute('aria-label', 'Copy email address');


### PR DESCRIPTION
## Summary
- Wrap obfuscated email text in its own span so the envelope icon remains visible
- Update email reveal script to fill only the dedicated span when revealing the address

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a2367a858083278598e43b8c51f9f0