### PR TITLE
Refine contact button copy

### DIFF
--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -16,7 +16,7 @@ author_profile: true
       <span class="contact-icon"><i class="fas fa-envelope" aria-hidden="true"></i></span>
       <span id="email-text">kir***.sha**.**@gmail.com</span>
     </a>
-    <button id="copy-email" class="copy-email-btn" aria-label="Reveal email address">Reveal Email</button>
+    <button id="copy-email" class="copy-email-btn" aria-label="Reveal email address">Reveal</button>
     <span id="copy-feedback" class="copy-feedback" aria-live="polite"></span>
   </div>
   <a class="contact-card contact-link"

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -36,7 +36,7 @@
             emailText.textContent = email;
           }
           link.href = 'mailto:' + email;
-          btn.textContent = 'Copy Email';
+          btn.textContent = 'Copy';
           btn.setAttribute('aria-label', 'Copy email address');
           revealed = true;
           return;


### PR DESCRIPTION
## Summary
- Update contact button text to "Reveal" and keep a descriptive aria-label
- Change copy action label to "Copy" for clearer toggle between states

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a23755e63c8327a1751a4a8c463b53