### PR TITLE
Reduce hero section heights for home and inner pages

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -101,6 +101,7 @@ button,
     linear-gradient(135deg, #ffffff 0%, #e0eaff 100%);
   color: var(--color-text);
   padding: 2rem 1rem;
+  min-height: 40vh;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -130,8 +131,8 @@ button,
     radial-gradient(circle at bottom right, rgba(0, 0, 0, 0.05), transparent 40%),
     linear-gradient(135deg, #ffffff 0%, #e0eaff 100%);
   color: var(--color-text);
-  padding: 4rem 1rem;
-  min-height: 100vh;
+  padding: 3rem 1rem;
+  min-height: 80vh;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- shrink home page hero section height and padding for a less dominant layout
- add 40vh min-height for page heroes to keep inner pages compact

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a23c06c93c8327ab3eeab11d33b27c