### PR TITLE
Add profile layout and update about and research pages

### DIFF
--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -1,0 +1,28 @@
+---
+layout: default
+---
+
+<div class="profile">
+  {% include hero.html %}
+
+  {% if page.bio %}
+  <section class="profile-bio">
+    {{ page.bio }}
+  </section>
+  {% endif %}
+
+  {% if page.projects %}
+  <section class="profile-projects">
+    <h2>Projects</h2>
+    <ul class="project-list">
+      {% for project in page.projects %}
+      <li>{{ project }}</li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+
+  <div class="profile-content">
+    {{ content }}
+  </div>
+</div>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -1,7 +1,7 @@
 ---
 permalink: /about/
 title: "About"
-layout: page
+layout: profile
 hero_title: "About Me"
 hero_tagline: "Software Engineer & AI Enthusiast"
 author_profile: true

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,6 +1,6 @@
 ---
 title: "Research"
-layout: page
+layout: profile
 permalink: /research/
 hero_title: "Research"
 hero_tagline: "Exploring Deep Learning & Computer Vision"


### PR DESCRIPTION
## Summary
- add profile layout extending default, including hero, optional bio/projects sections and profile-content container
- switch About and Research pages to new profile layout

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a23d9d3c24832798f94e0bf02346fb