### PR TITLE
Add research include and layout flag

### DIFF
--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -24,5 +24,8 @@ layout: default
 
   <div class="profile-content">
     {{ content }}
+    {% if page.show_research %}
+    {% include featured-research.html %}
+    {% endif %}
   </div>
 </div>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -12,3 +12,5 @@ My research focuses on applying deep learning and computer vision to solve real-
 I am particularly interested in neural networks for image understanding, automation, and intelligent systems.
 
 This page highlights ongoing projects, publications, and ideas I'm experimenting with.
+
+{% include featured-research.html %}


### PR DESCRIPTION
## Summary
- embed `featured-research.html` in the research page
- allow layouts to include the research grid via `show_research`

## Testing
- `curl -I https://github.com/kiranshahi/Robust-Video-Matting` *(fails: CONNECT tunnel failed, response 403)*
- `curl -I https://placehold.co/400x200?text=Real-Time+Video+Matting` *(fails: CONNECT tunnel failed, response 403)*
- `bundle exec jekyll build` *(fails: jekyll not installed; bundled command not found)*
- `bundle install` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a23ec5923c83278496c8c6161bff44