### PR TITLE
Organize about page with sections and CTA

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -6,14 +6,25 @@ hero_title: "About Me"
 hero_tagline: "Software Engineer & AI Enthusiast"
 author_profile: true
 ---
-👋 Hello, I'm Kiran Shahi, a software engineer from Pokhara, Nepal.
 
-💻 My journey in the world of technology began after completing my Bachelor's degree in Computing from Islington College in Kathmandu. In July 2017, I joined Braindigit as a software engineer, where I honed my skills and gained practical experience. It was during this time that my passion for software engineering and artificial intelligence, particularly deep learning, neural networks, and computer vision, flourished.
+<img src="{{ '/assets/images/bio-photo.jpg' | relative_url }}" alt="Kiran Shahi" class="bio-photo" />
 
-🎓 In March 2021, I decided to take my knowledge to the next level and pursued a Master of Science in Artificial Intelligence in London, United Kingdom. This educational endeavor allowed me to dive deeper into the field, expanding my expertise and fueling my enthusiasm for technology.
+<section id="background">
+<h2>Background</h2>
+<p>👋 Hello, I'm Kiran Shahi, a software engineer from Pokhara, Nepal.</p>
+<p>💻 My journey in the world of technology began after completing my Bachelor's degree in Computing from Islington College in Kathmandu. In July 2017, I joined Braindigit as a software engineer, where I honed my skills and gained practical experience. It was during this time that my passion for software engineering and artificial intelligence, particularly deep learning, neural networks, and computer vision, flourished.</p>
+<p>🎓 In March 2021, I decided to take my knowledge to the next level and pursued a Master of Science in Artificial Intelligence in London, United Kingdom. This educational endeavor allowed me to dive deeper into the field, expanding my expertise and fueling my enthusiasm for technology.</p>
+</section>
 
-💼 In January 2023, I embarked on a new chapter in my career as a software engineer at MBS Survey Software Ltd. Here, I have the opportunity to apply my knowledge and skills to real-world challenges, contributing to the development of innovative solutions.
+<section id="current-work">
+<h2>Current Work</h2>
+<p>💼 In January 2023, I embarked on a new chapter in my career as a software engineer at MBS Survey Software Ltd. Here, I have the opportunity to apply my knowledge and skills to real-world challenges, contributing to the development of innovative solutions.</p>
+</section>
 
-⏳ During my leisure time, I make it a priority to stay up to date with the latest tech advancements by exploring the internet and reading tech blogs. Additionally, I maintain an active and balanced lifestyle. As a 1-degree Seido Karate black belt and a fitness enthusiast, I embrace the physical aspect of personal growth alongside my love for technology.
+<section id="interests">
+<h2>Interests</h2>
+<p>⏳ During my leisure time, I make it a priority to stay up to date with the latest tech advancements by exploring the internet and reading tech blogs. Additionally, I maintain an active and balanced lifestyle. As a 1-degree Seido Karate black belt and a fitness enthusiast, I embrace the physical aspect of personal growth alongside my love for technology.</p>
+<p>🌟 I am passionate about leveraging my skills and knowledge to make a positive impact in the software engineering field. I am open to new opportunities and collaborations, so feel free to connect with me!</p>
+</section>
 
-🌟 I am passionate about leveraging my skills and knowledge to make a positive impact in the software engineering field. I am open to new opportunities and collaborations, so feel free to connect with me!
+<a href="/contact/" class="btn btn--primary btn--large">Let's Collaborate</a>


### PR DESCRIPTION
## Summary
- structure about page biography into Background, Current Work, and Interests sections
- add bio photo at top
- include collaboration call-to-action linking to contact page

## Testing
- `bundle install` *(fails: 403 Forbidden fetching gems)*
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a23fa8c38c83279e66e9618763c8bb