### PR TITLE
Style profile page layout and CTA button

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -9,22 +9,22 @@ author_profile: true
 
 <img src="{{ '/assets/images/bio-photo.jpg' | relative_url }}" alt="Kiran Shahi" class="bio-photo" />
 
-<section id="background">
+<section id="background" class="bio-section">
 <h2>Background</h2>
 <p>👋 Hello, I'm Kiran Shahi, a software engineer from Pokhara, Nepal.</p>
 <p>💻 My journey in the world of technology began after completing my Bachelor's degree in Computing from Islington College in Kathmandu. In July 2017, I joined Braindigit as a software engineer, where I honed my skills and gained practical experience. It was during this time that my passion for software engineering and artificial intelligence, particularly deep learning, neural networks, and computer vision, flourished.</p>
 <p>🎓 In March 2021, I decided to take my knowledge to the next level and pursued a Master of Science in Artificial Intelligence in London, United Kingdom. This educational endeavor allowed me to dive deeper into the field, expanding my expertise and fueling my enthusiasm for technology.</p>
 </section>
 
-<section id="current-work">
+<section id="current-work" class="bio-section">
 <h2>Current Work</h2>
 <p>💼 In January 2023, I embarked on a new chapter in my career as a software engineer at MBS Survey Software Ltd. Here, I have the opportunity to apply my knowledge and skills to real-world challenges, contributing to the development of innovative solutions.</p>
 </section>
 
-<section id="interests">
+<section id="interests" class="bio-section">
 <h2>Interests</h2>
 <p>⏳ During my leisure time, I make it a priority to stay up to date with the latest tech advancements by exploring the internet and reading tech blogs. Additionally, I maintain an active and balanced lifestyle. As a 1-degree Seido Karate black belt and a fitness enthusiast, I embrace the physical aspect of personal growth alongside my love for technology.</p>
 <p>🌟 I am passionate about leveraging my skills and knowledge to make a positive impact in the software engineering field. I am open to new opportunities and collaborations, so feel free to connect with me!</p>
 </section>
 
-<a href="/contact/" class="btn btn--primary btn--large">Let's Collaborate</a>
+<a href="/contact/" class="btn btn--primary btn--large cta">Let's Collaborate</a>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -467,3 +467,44 @@ button,
   white-space: nowrap;
 }
 
+/* Profile Page */
+.profile-content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  align-items: start;
+  margin-top: 2rem;
+}
+
+.profile-content .bio-photo {
+  width: 100%;
+  max-width: 250px;
+  height: auto;
+  border-radius: 50%;
+  justify-self: center;
+}
+
+.bio-section {
+  margin-bottom: 1.5rem;
+}
+
+.bio-section h2 {
+  margin-top: 0;
+}
+
+.cta {
+  margin-top: 1.5rem;
+  display: inline-block;
+  align-self: start;
+}
+
+@media (min-width: 768px) {
+  .profile-content {
+    grid-template-columns: 250px 1fr;
+  }
+
+  .profile-content .bio-photo {
+    justify-self: start;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add responsive profile section styles and CTA button options in `main.scss`
- Tag About page sections with `bio-section` classes and mark CTA button

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a240a049dc832786e00d6a57266e5e