### PR TITLE
Reduce page hero height

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -100,8 +100,8 @@ button,
     radial-gradient(circle at bottom right, rgba(0, 0, 0, 0.05), transparent 40%),
     linear-gradient(135deg, #ffffff 0%, #e0eaff 100%);
   color: var(--color-text);
-  padding: 2rem 1rem;
-  min-height: 40vh;
+  padding: 1rem 1rem;
+  min-height: 20vh;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Summary
- Decrease `.page-hero` minimum height and padding for a more compact hero section

## Testing
- `./build.sh` *(fails: jekyll missing)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a242cdeab08327a7400b069a534d4e