### PR TITLE
Condense about page with bullet sections

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -12,20 +12,44 @@ author_profile: true
 <div class="about-grid">
 <section id="background" class="bio-section">
 <h2>Background</h2>
+<ul>
+<li>Software engineer from Pokhara, Nepal</li>
+<li>BSc Computing from Islington College, Kathmandu</li>
+<li>Joined Braindigit in July 2017</li>
+<li>Passionate about deep learning, neural networks & computer vision</li>
+<li>MSc Artificial Intelligence in London (March 2021)</li>
+</ul>
+<details>
+<summary>More about my background</summary>
 <p>👋 Hello, I'm Kiran Shahi, a software engineer from Pokhara, Nepal.</p>
 <p>💻 My journey in the world of technology began after completing my Bachelor's degree in Computing from Islington College in Kathmandu. In July 2017, I joined Braindigit as a software engineer, where I honed my skills and gained practical experience. It was during this time that my passion for software engineering and artificial intelligence, particularly deep learning, neural networks, and computer vision, flourished.</p>
 <p>🎓 In March 2021, I decided to take my knowledge to the next level and pursued a Master of Science in Artificial Intelligence in London, United Kingdom. This educational endeavor allowed me to dive deeper into the field, expanding my expertise and fueling my enthusiasm for technology.</p>
+</details>
 </section>
 
 <section id="current-work" class="bio-section">
 <h2>Current Work</h2>
+<ul>
+<li>Software engineer at MBS Survey Software Ltd since January 2023</li>
+</ul>
+<details>
+<summary>More about my current work</summary>
 <p>💼 In January 2023, I embarked on a new chapter in my career as a software engineer at MBS Survey Software Ltd. Here, I have the opportunity to apply my knowledge and skills to real-world challenges, contributing to the development of innovative solutions.</p>
+</details>
 </section>
 
 <section id="interests" class="bio-section">
 <h2>Interests</h2>
+<ul>
+<li>Stay current with tech through blogs and online exploration</li>
+<li>1-degree Seido Karate black belt and fitness enthusiast</li>
+<li>Open to new opportunities and collaborations</li>
+</ul>
+<details>
+<summary>More about my interests</summary>
 <p>⏳ During my leisure time, I make it a priority to stay up to date with the latest tech advancements by exploring the internet and reading tech blogs. Additionally, I maintain an active and balanced lifestyle. As a 1-degree Seido Karate black belt and a fitness enthusiast, I embrace the physical aspect of personal growth alongside my love for technology.</p>
 <p>🌟 I am passionate about leveraging my skills and knowledge to make a positive impact in the software engineering field. I am open to new opportunities and collaborations, so feel free to connect with me!</p>
+</details>
 </section>
 </div>
 


### PR DESCRIPTION
## Summary
- streamline About page sections into concise bullet lists
- add collapsible details blocks with full text for background, work, and interests

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `./build.sh` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a244c76d4c8327a65aa91a5c19baaa