### PR TITLE
Add hero image and responsive layout

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,10 +1,15 @@
-{% if page.hero_title or page.hero_tagline %}
+{% if page.hero_title or page.hero_tagline or page.hero_image %}
 <section class="page-hero">
-  <div class="page__hero text-center">
-    <h1 class="page__title">{{ page.hero_title | default: page.title }}</h1>
-    {% if page.hero_tagline %}
-    <p class="page__lead">{{ page.hero_tagline }}</p>
+  <div class="page__hero text-center{% if page.hero_image %} page__hero--image{% endif %}">
+    {% if page.hero_image %}
+    <img src="{{ page.hero_image | relative_url }}" alt="{{ page.hero_image_alt | default: page.title }}" class="bio-photo">
     {% endif %}
+    <div class="hero-text">
+      <h1 class="page__title">{{ page.hero_title | default: page.title }}</h1>
+      {% if page.hero_tagline %}
+      <p class="page__lead">{{ page.hero_tagline }}</p>
+      {% endif %}
+    </div>
   </div>
 </section>
 {% endif %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -5,10 +5,9 @@ layout: profile
 hero_title: "About Me"
 hero_tagline: "Software Engineer & AI Enthusiast"
 author_profile: true
+hero_image: "/assets/images/bio-photo.jpg"
+hero_image_alt: "Kiran Shahi"
 ---
-
-<img src="{{ '/assets/images/bio-photo.jpg' | relative_url }}" alt="Kiran Shahi" class="bio-photo" />
-
 <div class="about-grid">
 <section id="background" class="bio-section">
 <h2>Background</h2>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -182,6 +182,38 @@ button,
   text-align: center;
 }
 
+.page__hero--image {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.page__hero--image .hero-text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.page__hero--image .bio-photo {
+  width: 100%;
+  max-width: 150px;
+  border-radius: 50%;
+}
+
+@media (min-width: 768px) {
+  .page__hero--image {
+    flex-direction: row;
+    justify-content: center;
+    text-align: left;
+  }
+
+  .page__hero--image .hero-text {
+    align-items: flex-start;
+    text-align: left;
+  }
+}
+
 .hero__actions,
 .connect__actions {
   display: flex;


### PR DESCRIPTION
## Summary
- Move bio photo into hero section with optional front matter image
- Layout hero content using flexbox for side-by-side image and text on large screens
- Provide front matter configuration for About page hero image

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a24634a1a88327ad0f23027661b340