### PR TITLE
Enable Jekyll SEO tag for better metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,6 @@ group :jekyll_plugins do
   gem "jekyll-feed"
   gem "jemoji"
   gem "jekyll-include-cache"
+  gem "jekyll-seo-tag"
   gem "jekyll-algolia"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,7 @@ plugins:
   - jekyll-feed
   - jemoji
   - jekyll-include-cache
+  - jekyll-seo-tag
 
 author:
   name   : "Kiran Shahi"
@@ -120,7 +121,7 @@ comments:
     theme: "github-light" # "github-dark"
     issue_term: "pathname"
 repository: "kiranshahi/comments"
-jekyll_seo_tag: false
+jekyll_seo_tag: true
 social:
   type:  "Person" # Person or Organization (defaults to Person)
   name:  "Kiran Shahi" # If the user or organization name differs from the site's name

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,6 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {% seo %}
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
   <link rel="stylesheet" href="{{ '/assets/css/print.css' | relative_url }}" media="print">
   {% include head/custom.html %}


### PR DESCRIPTION
## Summary
- enable `jekyll-seo-tag` plugin and remove manual canonical link

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a47fc60d108327ae4a0a1a0a5515cf