### PR TITLE
Remove redundant main.css include

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -7,7 +7,6 @@
      crossorigin="anonymous"></script>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
-<link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}" />
 <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/js/navigation.js' | relative_url }}" defer></script>
 


### PR DESCRIPTION
## Summary
- remove duplicate `/assets/css/main.css` link from custom head include
- leave single main stylesheet reference in `_includes/head.html`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a481c8342c83279e2b1d62edceb70b