### PR TITLE
feat: add skip link for accessibility

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,8 +5,11 @@ layout: null
 <html lang="{{ site.lang | default: 'en' }}">
   {% include head.html %}
   <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
     {% include header.html %}
-    {{ content }}
+    <main id="main-content">
+      {{ content }}
+    </main>
     {% include footer.html %}
     {% include scripts.html %}
   </body>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -42,6 +42,22 @@ button,
   font-weight: 600;
 }
 
+/* Accessibility Skip Link */
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--color-primary);
+  color: var(--color-background);
+  padding: 0.5rem 1rem;
+  z-index: 100;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  top: 0;
+}
+
 .featured-research {
   padding: 2rem 1rem;
 }


### PR DESCRIPTION
## Summary
- add "Skip to content" link after `<body>` and wrap main content in `<main>`
- style skip link for better visibility and focus behavior

## Testing
- `bundle exec jekyll build` *(fails: jekyll executable not found)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a4830d9bbc83278db3dda69fbffcf6