### PR TITLE
Trap focus within open navigation menu

### DIFF
--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -6,6 +6,8 @@
     if (!toggle || !menu || !nav) return;
 
     const links = menu.querySelectorAll('a');
+    const firstLink = links[0];
+    const lastLink = links[links.length - 1];
 
     function isMobile() {
       return window.getComputedStyle(toggle).display !== 'none';
@@ -55,8 +57,21 @@
     });
 
     document.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape' && toggle.getAttribute('aria-expanded') === 'true') {
+      if (toggle.getAttribute('aria-expanded') !== 'true') return;
+
+      if (e.key === 'Escape') {
         closeMenu();
+        return;
+      }
+
+      if (e.key === 'Tab' && links.length) {
+        if (e.shiftKey && document.activeElement === firstLink) {
+          e.preventDefault();
+          lastLink.focus();
+        } else if (!e.shiftKey && document.activeElement === lastLink) {
+          e.preventDefault();
+          firstLink.focus();
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- Cycle keyboard focus between first and last menu links when navigation menu is open
- Keep normal tabbing behavior once the menu closes

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a48565539c832798dbc91a7756588e