### PR TITLE
Remove manual social meta tags and set default logo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ github_username: kiranshahi
 minimal_mistakes_skin: default
 search: true
 url: "https://kirans.me/"
+logo: "/assets/images/kiran-shahi.JPG"
 
 # Build settings
 markdown: kramdown

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -10,15 +10,6 @@
 <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/js/navigation.js' | relative_url }}" defer></script>
 
-{% if page.url == "/" %}
-<meta property="og:title" content="{{ site.title }}">
-<meta property="og:description" content="{{ site.description | strip_newlines }}">
-<meta property="og:image" content="{{ '/assets/images/kiran-shahi.JPG' | relative_url }}">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="{{ site.title }}">
-<meta name="twitter:description" content="{{ site.description | strip_newlines }}">
-<meta name="twitter:image" content="{{ '/assets/images/kiran-shahi.JPG' | relative_url }}">
-{% endif %}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- remove manually specified OpenGraph and Twitter meta tags from the custom head include
- configure a site-wide logo so jekyll-seo-tag can provide `og:image` and `twitter:image`

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a48922aca48327ad0356868a65ccd0