### PR TITLE
Remove trailing slash from site URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ description: "Kiran Shahi is a tech enthusiast who loves to solve real-world cha
 github_username: kiranshahi
 minimal_mistakes_skin: default
 search: true
-url: "https://kirans.me/"
+url: "https://kirans.me"
 logo: "/assets/images/kiran-shahi.JPG"
 
 # Build settings


### PR DESCRIPTION
## Summary
- remove trailing slash from site URL in configuration

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a48aafa4b88327bd4437cf7f35d57f