### PR TITLE
Render Person JSON-LD only on homepage

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -10,6 +10,7 @@
 <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
 <script src="{{ '/assets/js/navigation.js' | relative_url }}" defer></script>
 
+{% if page.url == "/" %}
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -39,3 +40,4 @@
   ]
 }
 </script>
+{% endif %}


### PR DESCRIPTION
## Summary
- Restrict Person JSON-LD structured data to the homepage by wrapping the script in a page.url check.

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a48badbdb48327857ea5b4087c0d8c