### PR TITLE
Reduce hero spacing on profile pages

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -121,8 +121,7 @@ button,
   /* Light theme gradient */
   background: var(--hero-gradient-light);
   color: var(--color-text);
-  padding: 1rem 1rem;
-  min-height: 20vh;
+  padding: 0.5rem 1rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -146,7 +145,7 @@ button,
   /* Light theme gradient */
   background: var(--hero-gradient-light);
   color: var(--color-text);
-  padding: 3rem 1rem;
+  padding: 1.5rem 1rem;
   min-height: 80vh;
   display: flex;
   align-items: center;
@@ -190,7 +189,7 @@ button,
 
 .page__hero,
 .lets-connect {
-  padding: 3rem 1rem;
+  padding: 1.5rem 1rem;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- remove min-height and tighten padding in `.page-hero`
- shrink `.page__hero` and `.lets-connect` padding for profile layout

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `./build.sh` *(fails: jekyll not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48de3c3a88327b98064dc587fc19d