### PR TITLE
Expand research page with project highlights and milestones

### DIFF
--- a/_data/milestones.yml
+++ b/_data/milestones.yml
@@ -1,0 +1,9 @@
+- year: 2024
+  title: "Face Recognition Toolkit v1.0"
+  summary: "Released a modular pipeline for robust face detection and recognition."
+- year: 2023
+  title: "Automatic Vehicle Counting Deployed"
+  summary: "Launched traffic-monitoring system used for urban planning studies."
+- year: 2022
+  title: "Real-Time Video Matting"
+  summary: "Published method for live background removal in video streams."

--- a/_includes/featured-research.html
+++ b/_includes/featured-research.html
@@ -1,4 +1,5 @@
-<section class="featured-research">
+<section class="featured-research research-section">
+  <h2>Project Highlights</h2>
   <div class="research-grid">
     {% for project in site.data.research %}
     <a class="research-card" href="{{ project.link }}">
@@ -8,6 +9,18 @@
       <h3 class="research-card__title">{{ project.title }}</h3>
       <p class="research-card__summary">{{ project.summary }}</p>
     </a>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="research-section research-milestones">
+  <h2>Milestones &amp; Publications</h2>
+  <div class="timeline">
+    {% for milestone in site.data.milestones %}
+    <div class="timeline-item">
+      <span class="timeline-date">{{ milestone.year }}</span>
+      <p><strong>{{ milestone.title }}</strong> – {{ milestone.summary }}</p>
+    </div>
     {% endfor %}
   </div>
 </section>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -7,10 +7,21 @@ hero_tagline: "Exploring Deep Learning & Computer Vision"
 author_profile: true
 ---
 
-My research focuses on applying deep learning and computer vision to solve real-world problems.
+<div class="research-overview">
+  <section id="themes" class="research-section">
+    <h2>Research Themes</h2>
+    <p>My work centers on harnessing deep learning and computer vision to interpret visual data and build intelligent systems. I'm drawn to projects that turn raw pixels into actionable understanding.</p>
+  </section>
 
-I am particularly interested in neural networks for image understanding, automation, and intelligent systems.
+  <section id="current-projects" class="research-section">
+    <h2>Current Projects</h2>
+    <p>I'm exploring real-time video processing, efficient recognition pipelines, and applications that bring AI into everyday tools.</p>
+  </section>
 
-This page highlights ongoing projects, publications, and ideas I'm experimenting with.
+  <section id="future-directions" class="research-section">
+    <h2>Future Directions</h2>
+    <p>Going forward I plan to investigate lightweight models for edge devices and responsible approaches for deploying computer vision in the wild.</p>
+  </section>
+</div>
 
 {% include featured-research.html %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -544,6 +544,30 @@ button,
   line-height: 1.6;
 }
 
+.research-section {
+  margin-bottom: 1.5rem;
+  padding: 1.5rem;
+  background: var(--color-background);
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.research-section:hover {
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
+  transform: translateY(-4px);
+}
+
+.research-overview {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+}
+
+.research-milestones {
+  margin-top: 2rem;
+}
+
 details {
   margin-top: 0.5rem;
 }
@@ -616,6 +640,9 @@ details summary {
   }
 
   .about-grid {
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  }
+  .research-overview {
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- Expand research page with narrative sections for themes, current work, and future directions.
- Add milestone/publication timeline and headings to featured research component with data-driven entries.
- Style new research sections and timeline cards for responsive layout.

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a490d489648327859966c1ecf1e8d3