### PR TITLE
Remove hero variables from profile pages

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,11 +2,7 @@
 permalink: /about/
 title: "About"
 layout: profile
-hero_title: "About Me"
-hero_tagline: "Software Engineer & AI Enthusiast"
 author_profile: true
-hero_image: "/assets/images/bio-photo.jpg"
-hero_image_alt: "Kiran Shahi"
 ---
 
 <div class="about-grid">

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -2,8 +2,6 @@
 title: "Research"
 layout: profile
 permalink: /research/
-hero_title: "Research"
-hero_tagline: "Exploring Deep Learning & Computer Vision"
 author_profile: true
 ---
 


### PR DESCRIPTION
## Summary
- drop `hero_*` front matter variables from About and Research pages
- rely on `hero.html` include to skip hero section when these values are missing

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a492b834b48327a472777b41a5acaa