### PR TITLE
feat: add hero actions to pages

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -9,6 +9,13 @@
       {% if page.hero_tagline %}
       <p class="page__lead">{{ page.hero_tagline }}</p>
       {% endif %}
+      {% if page.hero_actions %}
+      <div class="hero__actions">
+        {% for action in page.hero_actions %}
+        <a class="btn btn--{% if forloop.first %}primary{% else %}secondary{% endif %} btn--large" href="{{ action.url }}">{{ action.text }}</a>
+        {% endfor %}
+      </div>
+      {% endif %}
     </div>
   </div>
 </section>

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -3,6 +3,13 @@ permalink: /about/
 title: "About"
 layout: profile
 author_profile: true
+hero_title: "About Me"
+hero_tagline: "Software Engineer & AI Researcher"
+hero_actions:
+  - text: "View Research"
+    url: "/research/"
+  - text: "Contact"
+    url: "/contact/"
 ---
 
 <div class="about-grid">

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -3,6 +3,13 @@ title: "Research"
 layout: profile
 permalink: /research/
 author_profile: true
+hero_title: "Research"
+hero_tagline: "Exploring computer vision and AI"
+hero_actions:
+  - text: "Current Projects"
+    url: "#current-projects"
+  - text: "Contact"
+    url: "/contact/"
 ---
 
 <div class="research-overview">


### PR DESCRIPTION
## Summary
- render optional hero action buttons in reusable hero include
- add hero actions to About and Research page front matter

## Testing
- `./build.sh` *(fails: bundler command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a493fa9fd0832795ddf27c54575ea4