### PR TITLE
Ensure secondary buttons keep light text on hover

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -680,3 +680,8 @@ details summary {
   }
 }
 
+
+.btn--secondary:hover,
+.btn--secondary:focus {
+    color: #fff !important; // keeps text light on hover
+}


### PR DESCRIPTION
## Summary
- Keep `.btn--secondary` text white on hover or focus so the contact button remains legible.

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a4979ef4c483279a9cb950ce9e60f2