### PR TITLE
Align profile content sections with main column

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -672,6 +672,10 @@ details summary {
     justify-self: start;
   }
 
+  .profile-content > :not(.page-nav) {
+    grid-column: 2;
+  }
+
   .about-grid {
     grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   }


### PR DESCRIPTION
## Summary
- Ensure profile content sections appear in the main column by default

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll; Install missing gem executables with `bundle install`)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a49a21ac28832785e232ec6aa67084