### PR TITLE
Use folded block for site description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,11 @@
 # in the templates via {{ site.myvariable }}.
 title: Kiran Shahi
 email: kiran.shahi.c3@gmail.com
-description: "Kiran Shahi is a tech enthusiast who loves to solve real-world challenges via computer programming. He is an aspiring Data Scientist and Artificial Intelligence engineer who graduated from Brunel University with MSc in Artificial Intelligence degree."
+description: >
+  Kiran Shahi is a tech enthusiast who loves to solve real-world challenges via
+  computer programming. He is an aspiring Data Scientist and Artificial
+  Intelligence engineer who graduated from Brunel University with MSc in
+  Artificial Intelligence degree.
 github_username: kiranshahi
 minimal_mistakes_skin: default
 search: true


### PR DESCRIPTION
## Summary
- replace multi-line description in `_config.yml` with YAML folded block so “aspiring” isn’t split

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a49f78301c8327aded50466423c116