### PR TITLE
Remove unused Algolia gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,4 @@ group :jekyll_plugins do
   gem "jemoji"
   gem "jekyll-include-cache"
   gem "jekyll-seo-tag"
-  gem "jekyll-algolia"
 end


### PR DESCRIPTION
## Summary
- remove unused `jekyll-algolia` dependency

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a17d9e1c83278f8c458d76647265