### PR TITLE
feat: add hero section icons

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -1,6 +1,12 @@
 {% if page.hero_title or page.hero_tagline or page.hero_image %}
 <section class="page-hero">
   <div class="page__hero text-center{% if page.hero_image %} page__hero--image{% endif %}">
+    <div class="hero-icons" aria-hidden="true">
+      <i class="fas fa-book"></i>
+      <i class="fas fa-code"></i>
+      <i class="fab fa-github"></i>
+      <i class="fas fa-brain"></i>
+    </div>
     {% if page.hero_image %}
     <img src="{{ page.hero_image | relative_url }}" alt="{{ page.hero_image_alt | default: page.title }}" class="bio-photo">
     {% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,6 +5,12 @@ layout: default
   <div class="home">
    <section class="home-hero">
      <div class="page__hero text-center">
+       <div class="hero-icons" aria-hidden="true">
+         <i class="fas fa-book"></i>
+         <i class="fas fa-code"></i>
+         <i class="fab fa-github"></i>
+         <i class="fas fa-brain"></i>
+       </div>
        <h1 class="page__title">{{ page.hero_title | default: page.title }}</h1>
       <p class="page__lead">{{ page.hero_tagline | default: page.description }}</p>
       <div class="hero__actions">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -187,7 +187,31 @@ button,
   }
 }
 
-.page__hero,
+.hero-icons {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  transform: translateY(-50%);
+  font-size: clamp(2rem, 4vw, 3rem);
+  opacity: 0.1;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.page__hero .hero-text,
+.page__hero img {
+  position: relative;
+  z-index: 1;
+}
+.page__hero {
+  padding: 1.5rem 1rem;
+  text-align: center;
+  position: relative;
+}
+
 .lets-connect {
   padding: 1.5rem 1rem;
   text-align: center;


### PR DESCRIPTION
## Summary
- add Font Awesome icons to hero sections on home and content pages
- style hero icons with low-opacity overlay and ensure hero content layers properly

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a572b20c8327847e3d06ec9f1e97