### PR TITLE
fix: stretch hero icons across hero background

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -193,7 +193,8 @@ button,
   left: 0;
   width: 100%;
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
+  gap: 3rem;
   transform: translateY(-50%);
   font-size: clamp(2rem, 4vw, 3rem);
   opacity: 0.1;
@@ -210,6 +211,7 @@ button,
   padding: 1.5rem 1rem;
   text-align: center;
   position: relative;
+  width: 100%;
 }
 
 .lets-connect {


### PR DESCRIPTION
## Summary
- make hero icons justify evenly with spacing
- ensure hero section spans full width

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a4a8e8fc5c8327befa9700ecdbb37f