### PR TITLE
Add blog intro and navigation links

### DIFF
--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -9,5 +9,16 @@ hero_actions:
     url: /feed.xml
 ---
 
-Welcome to the blog.
+Welcome to the blog—a mix of coding tutorials, AI explorations, and project updates.
+
+<nav class="page-nav">
+  <h2>Explore</h2>
+  <ul>
+    <li><a href="#recent-posts">Recent Posts</a></li>
+    <li><a href="/categories/">Categories</a></li>
+    <li><a href="/tags/">Tags</a></li>
+  </ul>
+</nav>
+
+<h2 id="recent-posts">Recent Posts</h2>
 


### PR DESCRIPTION
## Summary
- add introductory copy to blog page
- provide navigation links for recent posts, categories, and tags

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a4ac17dea08327ac349c708a62b05f