### PR TITLE
Add hero metadata to blog page

### DIFF
--- a/_pages/blog.md
+++ b/_pages/blog.md
@@ -3,10 +3,12 @@ title: "Blog"
 permalink: /blog/
 layout: blog
 hero_title: "Blog"
-hero_tagline: "Thoughts, tutorials, and updates"
+hero_tagline: "Thoughts on software and AI"
 hero_actions:
-  - text: "Subscribe"
-    url: /feed.xml
+  - text: "Categories"
+    url: /categories/
+  - text: "Contact"
+    url: /contact/
 ---
 
 Welcome to the blog—a mix of coding tutorials, AI explorations, and project updates.


### PR DESCRIPTION
## Summary
- add hero fields to blog page
- include links to categories and contact from hero

## Testing
- `./build.sh` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a4ae1f35e883278a9568cda2870197