### PR TITLE
Add CI build verification and HTML checks

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -8,13 +8,11 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build the site in the jekyll/builder container
-      run: |
-        docker run \
-        -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Build and verify site
+        run: bash build.sh

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,6 @@ group :jekyll_plugins do
   gem "jekyll-include-cache"
   gem "jekyll-seo-tag"
 end
+
+# Additional tooling for CI
+gem "html-proofer"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # kiranshahi.github.io
 This is my personal portfolio website ! :bowtie:
+
+## Development
+
+1. Install dependencies:
+   ```
+   bundle install
+   ```
+2. Build the site and run checks:
+   ```
+   bash build.sh
+   ```
+   This verifies the blog index has a hero section and post list and runs `html-proofer` to check links and structure.

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,22 @@
 #!/bin/bash
 set -e
+
+# Build the site
 bundle exec jekyll build
+
+BLOG_PAGE="_site/blog/index.html"
+
+# Verify hero section exists
+if ! grep -q '<section class="page-hero"' "$BLOG_PAGE"; then
+  echo "Missing hero section in $BLOG_PAGE" >&2
+  exit 1
+fi
+
+# Verify post list exists
+if ! grep -q '<section class="blog-posts"' "$BLOG_PAGE"; then
+  echo "Missing post list in $BLOG_PAGE" >&2
+  exit 1
+fi
+
+# Check links and structure
+bundle exec htmlproofer ./_site --disable-external


### PR DESCRIPTION
## Summary
- build site and run htmlproofer with hero/post checks
- document development instructions
- run build script in CI

## Testing
- `bash build.sh` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b16d59908327ac84ea6fff131675