### PR TITLE
feat: redesign post details layout

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,7 +98,7 @@ defaults:
       path: ""
       type: posts
     values:
-      layout: single
+      layout: post
       author_profile: true
       read_time: true
       comments: true

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,53 @@
+---
+layout: default
+---
+
+<article class="post-detail">
+  <header class="post-detail__header">
+    <h1 class="post-detail__title">{{ page.title }}</h1>
+    <div class="post-detail__meta">
+      <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %-d, %Y" }}</time>
+      {% if page.last_modified_at %}
+      <span class="post-detail__updated"> • Updated on {{ page.last_modified_at | date: "%B %-d, %Y" }}</span>
+      {% endif %}
+      {% assign words = content | strip_html | number_of_words %}
+      {% assign mins = words | divided_by:200 | plus:1 %}
+      <span class="post-detail__reading-time"> • {{ mins }} min read</span>
+    </div>
+  </header>
+
+  <div class="post-detail__content">
+    {{ content }}
+  </div>
+
+  <footer class="post-detail__footer">
+    {% if page.share %}
+    <section class="post-detail__share">
+      <h2 class="post-detail__footer-title">Share</h2>
+      {% include share.html %}
+    </section>
+    {% endif %}
+
+    {% if page.related %}
+    <section class="post-detail__related">
+      <h2 class="post-detail__footer-title">Related Posts</h2>
+      {% include related.html %}
+    </section>
+    {% endif %}
+
+    <nav class="post-detail__pagination">
+      {% if page.previous.url %}
+      <a class="post-detail__prev" href="{{ page.previous.url | relative_url }}">&larr; {{ page.previous.title }}</a>
+      {% endif %}
+      {% if page.next.url %}
+      <a class="post-detail__next" href="{{ page.next.url | relative_url }}">{{ page.next.title }} &rarr;</a>
+      {% endif %}
+    </nav>
+
+    {% if page.comments %}
+    <section class="post-detail__comments">
+      {% include comments.html %}
+    </section>
+    {% endif %}
+  </footer>
+</article>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -776,3 +776,50 @@ details summary {
   line-height: 1.6;
 }
 
+
+/* Post detail layout */
+.post-detail {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.post-detail__header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.post-detail__meta {
+  color: #6c757d;
+  font-size: 0.9rem;
+}
+
+.post-detail__content {
+  line-height: 1.8;
+}
+
+.post-detail__footer {
+  margin-top: 3rem;
+}
+
+.post-detail__footer-title {
+  font-size: 1.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.post-detail__share,
+.post-detail__related,
+.post-detail__comments {
+  margin-top: 2rem;
+}
+
+.post-detail__pagination {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2rem;
+}
+
+.post-detail__pagination a {
+  text-decoration: none;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- add custom `post` layout with updated metadata, sharing, related posts, pagination, and comments sections
- switch default post layout to `post`
- style post detail page for improved readability and navigation

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*


------
https://chatgpt.com/codex/tasks/task_e_68a4b1fe55e88327adc35abdfbf6718e