### PR TITLE
Adjust hero icons positioning on mobile

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -281,6 +281,11 @@ button,
   .connect__actions .btn {
     width: 100%;
   }
+
+  .hero-icons {
+    top: 20%;
+    transform: none;
+  }
 }
 
 .contact-hero {


### PR DESCRIPTION
## Summary
- Move hero icons higher on small screens by adjusting top offset and removing vertical transform.

## Testing
- `bundle install` (fails: 403 Forbidden)
- `bundle exec jekyll build` (fails: command not found)
- `npx --yes sass --version` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a4b537ee688327bd203b150972f6b7