### PR TITLE
Add related posts include

### DIFF
--- a/_includes/related.html
+++ b/_includes/related.html
@@ -1,0 +1,7 @@
+{% if page.related_posts %}
+  <ul class="related-posts">
+    {% for post in page.related_posts %}
+      <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+    {% endfor %}
+  </ul>
+{% endif %}


### PR DESCRIPTION
## Summary
- add `_includes/related.html` to render related posts list

## Testing
- `bundle install` *(fails: 403 "Forbidden")*
- `./build.sh` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b7d75eb48327aca361cf6897d2be