### PR TITLE
Remove sustainable engineering/daylight content and replace with research software wording

### DIFF
--- a/about.md
+++ b/about.md
@@ -7,7 +7,7 @@ permalink: /about/
 
 I am a researcher and software engineer working at the intersection of artificial intelligence, computer vision, medical imaging, and engineering software systems. My goal is to develop AI methods that are both scientifically meaningful and practically deployable.
 
-My work combines two complementary directions. The first is research in visual AI, particularly in medical imaging, explainability, segmentation, localization, and temporal vision problems. The second is applied software development, where I build engineering tools and intelligent platforms for real-world use cases such as daylight-related simulation systems.
+My work combines two complementary directions. The first is research in visual AI, particularly in medical imaging, explainability, segmentation, localization, and temporal vision problems. The second is applied software development, where I build engineering tools and intelligent platforms for real-world use cases such as research-oriented simulation and analysis systems.
 
 I am especially drawn to research questions that sit between disciplines: where physics-based reasoning, visual learning, uncertainty estimation, and system design come together. I believe some of the most valuable AI systems will emerge not from isolated models, but from careful integration of domain knowledge, trustworthy evaluation, and strong engineering.
 
@@ -19,7 +19,6 @@ My current interests include:
 - Weakly supervised learning
 - Uncertainty-aware segmentation
 - Video matting and temporal vision
-- AI for sustainable buildings and environmental analytics
 - Research software engineering
 
 In the long term, I aim to build a strong research profile through publications, open-source tools, and impactful interdisciplinary projects, while contributing to both academia and research-driven product development.

--- a/contact.md
+++ b/contact.md
@@ -14,7 +14,6 @@ I welcome conversations related to:
 - Open-source projects
 - Computer vision and medical imaging
 - Explainable AI
-- AI for sustainable engineering systems
 
 ## Email
 
@@ -30,4 +29,4 @@ your-email@example.com
 
 ## Collaboration Note
 
-I am particularly interested in interdisciplinary collaborations that connect AI research, scientific rigor, and practical systems. If your work aligns with computer vision, medical imaging, explainable AI, or sustainable engineering applications, I would be glad to connect.
+I am particularly interested in interdisciplinary collaborations that connect AI research, scientific rigor, and practical systems. If your work aligns with computer vision, medical imaging, explainable AI, or applied AI software applications, I would be glad to connect.

--- a/cv.md
+++ b/cv.md
@@ -11,7 +11,7 @@ A full academic CV is available for download below.
 
 ## Profile Summary
 
-Researcher and software engineer with interests in artificial intelligence, computer vision, medical imaging, explainable AI, and sustainable engineering systems. Experienced in both research-oriented development and production-focused software engineering.
+Researcher and software engineer with interests in artificial intelligence, computer vision, medical imaging, explainable AI, and research software systems. Experienced in both research-oriented development and production-focused software engineering.
 
 ## Research Areas
 
@@ -21,7 +21,6 @@ Researcher and software engineer with interests in artificial intelligence, comp
 - Weakly Supervised Learning
 - Uncertainty-Aware AI
 - Video Matting
-- Sustainable Engineering AI
 - Research Software Systems
 
 ## Education

--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@ layout: default
 <section class="hero">
   <div>
     <h1>Kiran Shahi</h1>
-    <h3>AI Researcher | Computer Vision Engineer | Applied AI for Medical Imaging and Sustainable Systems</h3>
-    <p>I build research-driven AI systems at the intersection of computer vision, medical imaging, explainable AI, and engineering software. My work combines scientific research with real-world product development, with a focus on trustworthy AI, visual intelligence, and deployable tools for healthcare and sustainability.</p>
+    <h3>AI Researcher | Computer Vision Engineer | Applied AI for Medical Imaging and Research Software</h3>
+    <p>I build research-driven AI systems at the intersection of computer vision, medical imaging, explainable AI, and engineering software. My work combines scientific research with real-world product development, with a focus on trustworthy AI, visual intelligence, and deployable tools for healthcare applications.</p>
     <div class="btn-row">
       <a class="btn primary" href="{{ '/publications/' | relative_url }}">View Publications</a>
       <a class="btn" href="{{ '/projects/' | relative_url }}">Explore Projects</a>
@@ -42,8 +42,8 @@ layout: default
       <p>Studying how model decisions can be interpreted and trusted, especially in high-stakes domains such as healthcare.</p>
     </article>
     <article class="card">
-      <h3>Sustainable Engineering AI</h3>
-      <p>Applying AI and physics-informed analysis to daylight performance and built-environment software systems.</p>
+      <h3>Research Software Systems</h3>
+      <p>Designing practical AI software systems that connect experiments, model outputs, and deployable workflows.</p>
     </article>
   </div>
 </section>
@@ -53,14 +53,14 @@ layout: default
   <ul>
     <li>Weakly Supervised Pneumonia Localization from Chest X-Rays</li>
     <li>Uncertainty-Aware Lung Segmentation</li>
-    <li>Daylight and Sustainable Building Intelligence</li>
+    <li>Research-Driven AI Software Systems</li>
     <li>Temporal Video Matting Research</li>
   </ul>
 </section>
 
 <section class="section card">
   <h2>Quick Bio</h2>
-  <p>Kiran Shahi is a researcher and software engineer working in artificial intelligence, computer vision, medical imaging, explainable AI, and sustainable engineering software. His work focuses on building trustworthy and deployable AI systems that connect scientific research with practical impact.</p>
+  <p>Kiran Shahi is a researcher and software engineer working in artificial intelligence, computer vision, medical imaging, explainable AI, and research software systems. His work focuses on building trustworthy and deployable AI systems that connect scientific research with practical impact.</p>
 </section>
 
 <section class="section card">

--- a/projects.md
+++ b/projects.md
@@ -19,19 +19,13 @@ A segmentation project using nnU-Net v2 ensembles to study predictive confidence
 
 **Focus areas:** segmentation, uncertainty estimation, ensemble learning, clinical reliability
 
-## 3. Daylight and Sustainable Building Intelligence
-
-An applied AI direction centered on daylight simulation, visual building analysis, and intelligent tools for sustainable design workflows. This work aims to connect simulation, geometry, and AI into practical engineering products.
-
-**Focus areas:** AI for buildings, simulation tools, environmental analysis
-
-## 4. Temporal Video Matting Research
+## 3. Temporal Video Matting Research
 
 An ongoing research direction exploring temporal consistency, edge fidelity, and efficient modeling for video matting. The aim is to build systems that are accurate, lightweight, and capable of handling challenging temporal variations.
 
 **Focus areas:** video matting, temporal learning, real-time vision, visual quality
 
-## 5. Research-Driven AI Software Systems
+## 4. Research-Driven AI Software Systems
 
 Beyond individual research prototypes, I am interested in designing full-stack AI systems that connect model outputs with usable interfaces, reproducible workflows, and real-world deployment.
 

--- a/publications.md
+++ b/publications.md
@@ -44,7 +44,6 @@ My publication roadmap currently centers on the following themes:
 - Explainable AI in healthcare
 - Uncertainty-aware segmentation
 - Temporal vision and video matting
-- AI for sustainable engineering and environmental analytics
 
 ## Notes
 

--- a/research.md
+++ b/research.md
@@ -31,10 +31,6 @@ Reliable deployment requires models to know when they may be wrong. I am interes
 
 I am interested in temporal consistency, edge fidelity, and memory mechanisms for video understanding problems, particularly in tasks such as real-time background matting.
 
-## AI for Sustainable Systems
-
-I also work on AI-driven and physics-informed tools for daylight evaluation and engineering software. This reflects my interest in applying visual intelligence beyond traditional academic benchmarks toward sustainability and built-environment challenges.
-
 ## Research Statement
 
-My research aims to build AI systems that are not only accurate, but also interpretable, robust, and usable in real-world settings. I am especially interested in domains where trust matters, such as healthcare and sustainability. Across my projects, I try to combine principled methodology, strong evaluation, and practical deployment thinking so that the resulting work contributes both to science and to real applications.
+My research aims to build AI systems that are not only accurate, but also interpretable, robust, and usable in real-world settings. I am especially interested in domains where trust matters, such as healthcare. Across my projects, I try to combine principled methodology, strong evaluation, and practical deployment thinking so that the resulting work contributes both to science and to real applications.


### PR DESCRIPTION
### Motivation

- Remove references to Sustainable Engineering AI and daylight-focused content across the site to focus the profile on medical imaging, computer vision, and research software systems. 
- Ensure site copy is consistent and does not reference daylight or sustainability topics.

### Description

- Replaced homepage hero and quick-bio wording and swapped the "Sustainable Engineering AI" featured card for a "Research Software Systems" card in `index.html`. 
- Removed the "Daylight and Sustainable Building Intelligence" project section and renumbered subsequent project sections in `projects.md`. 
- Cleaned related mentions across `about.md`, `cv.md`, `contact.md`, `publications.md`, and `research.md` to remove daylight/sustainable wording and align phrasing to research software and applied AI. 
- This is a content-only cleanup with no functional code changes.

### Testing

- Searched the repository for remaining keywords with `rg -n "Sustainable Engineering AI|daylight|Daylight|sustainable" .` and confirmed no matches were found. 
- Launched a local server with `python -m http.server` and captured an updated homepage screenshot saved as `artifacts/index-updated.png` using a Playwright script. 
- Verified the working tree reflected the applied changes and that the modified pages show the updated copy as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b42bb3695883279da91b11dc65a81d)