### PR TITLE
Remove jekyll-seo-tag plugin from _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,6 @@ permalink: /:categories/:title/
 timezone: UTC
 
 plugins:
-  - jekyll-seo-tag
   - jekyll-sitemap
   - jekyll-feed
 


### PR DESCRIPTION
Removed jekyll-seo-tag plugin from configuration.